### PR TITLE
zoom relative poi sizing support (wip)

### DIFF
--- a/packages/example-floors/src/floors.ts
+++ b/packages/example-floors/src/floors.ts
@@ -2,7 +2,35 @@ import { type FloorsConfig } from 'svgmapviewer'
 
 import { floors } from './data/floors'
 
+const labelsMap = new Map([
+  [
+    '1f',
+    [
+      {
+        attrs: {
+          x: 100,
+          y: 100,
+          rotate: 90,
+          scale2: 1,
+          scale1: 1,
+          dy: 0,
+        },
+        children: [
+          {
+            attrs: {
+              x: 0,
+              y: 0,
+            },
+            text: '日本語のテスト',
+          },
+        ],
+      },
+    ],
+  ],
+])
+
 export const floorsConfig: FloorsConfig = {
   floors,
   initialFidx: 0,
+  labelsMap,
 }

--- a/packages/example-osm/src/main.ts
+++ b/packages/example-osm/src/main.ts
@@ -7,4 +7,5 @@ svgmapviewer({
   root: 'root',
   title: 'Yugyoji',
   mapData,
+  uiConfig: { showGuides: true },
 })

--- a/packages/lib/src/App.css
+++ b/packages/lib/src/App.css
@@ -58,6 +58,16 @@
   inherits: false;
   initial-value: 1;
 }
+@property --distance-idx {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --distance-radius-client {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0;
+}
 @property --layout-container-height {
   syntax: '<length>';
   inherits: false;

--- a/packages/lib/src/App.css
+++ b/packages/lib/src/App.css
@@ -8,6 +8,16 @@
   inherits: false;
   initial-value: 1;
 }
+@property --balloon-phh {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --balloon-pww {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
 @property --balloon-scale {
   syntax: '<number>';
   inherits: false;
@@ -19,6 +29,26 @@
   initial-value: 0;
 }
 @property --balloon-translate-y {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --balloon-tx-a-x {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --balloon-tx-a-y {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --balloon-tx-b-x {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --balloon-tx-b-y {
   syntax: '<length>';
   inherits: false;
   initial-value: 0;
@@ -68,37 +98,17 @@
   inherits: false;
   initial-value: matrix(1, 0, 0, 1, 0, 0);
 }
-@property --phh {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
 @property --poi-scale {
   syntax: '<number>';
   inherits: false;
   initial-value: 1;
 }
-@property --pww {
+@property --poi-x {
   syntax: '<length>';
   inherits: false;
   initial-value: 0;
 }
-@property --tx-a-x {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --tx-a-y {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --tx-b-x {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --tx-b-y {
+@property --poi-y {
   syntax: '<length>';
   inherits: false;
   initial-value: 0;

--- a/packages/lib/src/App.css
+++ b/packages/lib/src/App.css
@@ -1,74 +1,14 @@
-@property --zoom-origin {
-  syntax: '<length-percentage>+';
-  inherits: false;
-  initial-value: 0% 0%;
-}
-@property --zoom-zoom {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
-@property --zoom-tx {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --zoom-ty {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --zoom-s {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
-@property --zoom-s-symbols {
-  syntax: '<number>';
-  inherits: true;
-  initial-value: 1;
-}
-@property --zoom-s-inv {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
-@property --zoom-z {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
-@property --zoom-z-inv {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
-@property --zoom-k {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
-@property --zoom-k-inv {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
-@property --zoom-s-inv-symbols {
-  syntax: '<number>';
-  inherits: true;
-  initial-value: 1;
-}
 @property --a {
   syntax: '<number>';
   inherits: false;
   initial-value: 1;
 }
-@property --b {
+@property --balloon-opacity {
   syntax: '<number>';
   inherits: false;
   initial-value: 1;
 }
-@property --balloon-opacity {
+@property --balloon-scale {
   syntax: '<number>';
   inherits: false;
   initial-value: 1;
@@ -83,17 +23,62 @@
   inherits: false;
   initial-value: 0;
 }
-@property --balloon-scale {
+@property --b {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --layout-container-height {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-container-width {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-content-matrix {
+  syntax: '*';
+  inherits: false;
+  initial-value: matrix(1, 0, 0, 1, 0, 0);
+}
+@property --layout-fontsize {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 16;
+}
+@property --layout-scroll-height {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-scroll-width {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-svgscale {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 1;
+}
+@property --layout-svg-to-content-matrix {
+  syntax: '*';
+  inherits: false;
+  initial-value: matrix(1, 0, 0, 1, 0, 0);
+}
+@property --phh {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --poi-scale {
   syntax: '<number>';
   inherits: false;
   initial-value: 1;
 }
 @property --pww {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --phh {
   syntax: '<length>';
   inherits: false;
   initial-value: 0;
@@ -118,47 +103,62 @@
   inherits: false;
   initial-value: 0;
 }
-@property --layout-container-width {
-  syntax: '<length>';
+@property --zoom-k-inv {
+  syntax: '<number>';
   inherits: false;
-  initial-value: 0;
+  initial-value: 1;
 }
-@property --layout-container-height {
-  syntax: '<length>';
+@property --zoom-k {
+  syntax: '<number>';
   inherits: false;
-  initial-value: 0;
+  initial-value: 1;
 }
-@property --layout-content-matrix {
-  syntax: '*';
+@property --zoom-origin {
+  syntax: '<length-percentage>+';
   inherits: false;
-  initial-value: matrix(1, 0, 0, 1, 0, 0);
+  initial-value: 0% 0%;
 }
-@property --layout-svg-to-content-matrix {
-  syntax: '*';
-  inherits: false;
-  initial-value: matrix(1, 0, 0, 1, 0, 0);
-}
-@property --layout-scroll-width {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --layout-scroll-height {
-  syntax: '<length>';
-  inherits: false;
-  initial-value: 0;
-}
-@property --layout-svgscale {
+@property --zoom-s-inv-symbols {
   syntax: '<number>';
   inherits: true;
   initial-value: 1;
 }
-@property --layout-fontsize {
+@property --zoom-s-inv {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --zoom-s-symbols {
   syntax: '<number>';
   inherits: true;
-  initial-value: 16;
+  initial-value: 1;
 }
-@property --poi-scale {
+@property --zoom-s {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --zoom-tx {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --zoom-ty {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --zoom-z-inv {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --zoom-zoom {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --zoom-z {
   syntax: '<number>';
   inherits: false;
   initial-value: 1;

--- a/packages/lib/src/App.css
+++ b/packages/lib/src/App.css
@@ -1,6 +1,5 @@
-export const propertiesStyle = `
 @property --zoom-origin {
-  syntax: "<length-percentage>+";
+  syntax: '<length-percentage>+';
   inherits: false;
   initial-value: 0% 0%;
 }
@@ -130,12 +129,12 @@ export const propertiesStyle = `
   initial-value: 0;
 }
 @property --layout-content-matrix {
-  syntax: "*";
+  syntax: '*';
   inherits: false;
   initial-value: matrix(1, 0, 0, 1, 0, 0);
 }
 @property --layout-svg-to-content-matrix {
-  syntax: "*";
+  syntax: '*';
   inherits: false;
   initial-value: matrix(1, 0, 0, 1, 0, 0);
 }
@@ -159,4 +158,8 @@ export const propertiesStyle = `
   inherits: true;
   initial-value: 16;
 }
-`
+@property --poi-scale {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}

--- a/packages/lib/src/App.tsx
+++ b/packages/lib/src/App.tsx
@@ -11,13 +11,14 @@ import {
   touch_action_none,
   width_100vw_height_100svh,
 } from './lib/css'
-import { propertiesStyle } from './lib/css/property'
 import { notifyGlobal } from './lib/event-global'
 import { likeStyle } from './lib/like/Like'
 import { useRendered } from './lib/style/style-react'
 import { Ui } from './lib/ui/Ui'
 import { Container } from './lib/viewer/Container'
 import { type OsmRenderMapProps } from './types'
+
+import './App.css'
 
 function App(): ReactNode {
   const cfg = useConfig()
@@ -79,8 +80,6 @@ a:link {
 }
 
 ${likeStyle}
-
-${propertiesStyle}
 `
 
 // XXX

--- a/packages/lib/src/App.tsx
+++ b/packages/lib/src/App.tsx
@@ -11,14 +11,13 @@ import {
   touch_action_none,
   width_100vw_height_100svh,
 } from './lib/css'
+import { properties } from './lib/css/property'
 import { notifyGlobal } from './lib/event-global'
 import { likeStyle } from './lib/like/Like'
 import { useRendered } from './lib/style/style-react'
 import { Ui } from './lib/ui/Ui'
 import { Container } from './lib/viewer/Container'
 import { type OsmRenderMapProps } from './types'
-
-import './App.css'
 
 function App(): ReactNode {
   const cfg = useConfig()
@@ -53,11 +52,9 @@ const style = `
   font-weight: lighter;
   user-select: none;
 }
-
 html, body {
   overflow: hidden;
 }
-
 body {
   ${position_absolute_left_0_top_0}
   ${width_100vw_height_100svh}
@@ -66,20 +63,17 @@ body {
   ${touch_action_none}
   background-color: darkgray;
 }
-
 svg {
   display: block;
 }
-
 ul {
   list-style: none;
 }
-
 a:link {
   text-decoration: none;
 }
-
 ${likeStyle}
+${properties}
 `
 
 // XXX

--- a/packages/lib/src/lib/carto/markers.tsx
+++ b/packages/lib/src/lib/carto/markers.tsx
@@ -4,7 +4,7 @@ import { useMemo, useRef, type PropsWithChildren, type ReactNode } from 'react'
 import { type OsmRenderMapProps } from '../../types'
 import { useMapStyleRef } from '../map/style'
 import { usePosition } from '../position'
-import { useLayoutSvgScaleS } from '../style/style-react'
+//import { useLayoutSvgScaleS } from '../style/style-react'
 import { type V } from '../tuple'
 import { trunc2 } from '../utils'
 import { type MapMarker, type RenderMapMarkersProps } from './types'
@@ -153,8 +153,8 @@ export function RenderPositionStyle(
   >
 ): ReactNode {
   const position = usePosition()
-  const s = useLayoutSvgScaleS()
-  const sz = s * props.fontSize * 0.9
+  //const s = useLayoutSvgScaleS()
+  //const sz = s * props.fontSize * 0.9
 
   if (position === null) {
     return (
@@ -174,7 +174,7 @@ export function RenderPositionStyle(
     <>{`
 #position {
   display: initial !important;
-  transform: translate(${x}px, ${y}px) scale(${sz});
+  transform: translate(${x}px, ${y}px) scale(calc(var(--layout-svgscale) * var(--layout-fontsize) * 0.9));
 }
 `}</>
   )

--- a/packages/lib/src/lib/carto/markers.tsx
+++ b/packages/lib/src/lib/carto/markers.tsx
@@ -1,16 +1,16 @@
 /* eslint-disable functional/no-expression-statements */
-import { useMemo, useRef, type ReactNode } from 'react'
+import { useMemo, useRef, type PropsWithChildren, type ReactNode } from 'react'
 
 import { type OsmRenderMapProps } from '../../types'
 import { useMapStyleRef } from '../map/style'
 import { usePosition } from '../position'
+import { useLayoutSvgScaleS } from '../style/style-react'
 import { type V } from '../tuple'
 import { trunc2 } from '../utils'
-import { entryToVs } from './point'
 import { type MapMarker, type RenderMapMarkersProps } from './types'
 
 export function RenderMapMarkers(
-  props: Readonly<OsmRenderMapProps & RenderMapMarkersProps>
+  props: Readonly<PropsWithChildren<OsmRenderMapProps & RenderMapMarkersProps>>
 ): ReactNode {
   const ref = useRef<SVGGElement>(null)
 
@@ -20,17 +20,7 @@ export function RenderMapMarkers(
 
   return (
     <defs ref={ref} className="map-markers">
-      {props.mapMarkers.map((entry, i) => (
-        <g key={i}>
-          <RenderUses
-            m={props.m}
-            sz={sz}
-            name={entry.name}
-            href={entry.name} // XXX XXX XXX
-            vs={entryToVs(props.data.mapData, entry)}
-          />
-        </g>
-      ))}
+      {props.children}
       <RenderCircle sz={sz} />
       <RenderPosition sz={sz} />
       <style>
@@ -40,7 +30,7 @@ export function RenderMapMarkers(
   )
 }
 
-function RenderUses(
+export function RenderMarkerUses(
   props: Readonly<{
     m: DOMMatrixReadOnly
     sz: number
@@ -159,12 +149,12 @@ export function RenderPositionStyle(
   props: Readonly<
     OsmRenderMapProps & {
       fontSize: number
-      s: number
     }
   >
 ): ReactNode {
   const position = usePosition()
-  const sz = props.s * props.fontSize * 0.9
+  const s = useLayoutSvgScaleS()
+  const sz = s * props.fontSize * 0.9
 
   if (position === null) {
     return (

--- a/packages/lib/src/lib/carto/markers.tsx
+++ b/packages/lib/src/lib/carto/markers.tsx
@@ -7,6 +7,7 @@ import { usePosition } from '../position'
 //import { useLayoutSvgScaleS } from '../style/style-react'
 import { type V } from '../tuple'
 import { trunc2 } from '../utils'
+import { useSvgScaleStyleRef } from '../viewer/layout/style'
 import { type MapMarker, type RenderMapMarkersProps } from './types'
 
 export function RenderMapMarkers(
@@ -102,10 +103,13 @@ export function RenderCircle(props: Readonly<{ sz: number }>): ReactNode {
 }
 
 export function RenderPosition(props: Readonly<{ sz: number }>): ReactNode {
+  const ref = useRef(null)
+  useSvgScaleStyleRef(ref, 'position')
   const r = props.sz / 2
   const h = r / Math.sqrt(2)
   return (
     <path
+      ref={ref}
       id="position"
       className="position"
       fill="red"

--- a/packages/lib/src/lib/carto/symbols.tsx
+++ b/packages/lib/src/lib/carto/symbols.tsx
@@ -37,36 +37,55 @@ export function RenderMapSymbols(
   )
 }
 
+// XXX
+// XXX
+// XXX
+// XXX
+// XXX
+// XXX NOT working on Safari
+// XXX
+// XXX
+// XXX
+// XXX
+// XXX
+
 const style = `
 .map-symbols {
   & > .map-symbol {
-    translate: var(--map-symbol-x) var(--map-symbol-y);
-    scale: calc(var(--layout-fontsize) * 1.5 * var(--layout-svgscale) / 72);
+    transform:
+      translate(var(--map-symbol-x), var(--map-symbol-y))
+      scale(calc(var(--layout-fontsize) * 1.5 * var(--layout-svgscale) / 72));
   }
   &.zooming {
     & > .map-symbol {
-      will-change: scale;
-      animation: xxx-map-symbol 500ms ease;
+      will-change: transform;
+      animation: xxx-map-symbol 500ms ease forwards;
     }
   }
 }
 @keyframes xxx-map-symbol {
   from {
-    scale:
-      calc(
-        var(--layout-fontsize) *
-        1.5 *
-        var(--layout-svgscale) /
-        72);
+    transform:
+      translate(var(--map-symbol-x), var(--map-symbol-y))
+      scale(
+        calc(
+          var(--layout-fontsize) *
+          1.5 *
+          var(--layout-svgscale) /
+          72))
+      translate3d(0,0,0);
   }
   to {
-    scale:
-      calc(
-        1 / var(--zoom-s) *
-        var(--layout-fontsize) *
-        1.5 *
-        var(--layout-svgscale) /
-        72);
+    transform:
+      translate(var(--map-symbol-x), var(--map-symbol-y))
+      scale(
+        calc(
+          1 / var(--zoom-s-symbols) *
+          var(--layout-fontsize) *
+          1.5 *
+          var(--layout-svgscale) /
+          72))
+      translate3d(0,0,0);
   }
 }
 `

--- a/packages/lib/src/lib/carto/symbols.tsx
+++ b/packages/lib/src/lib/carto/symbols.tsx
@@ -5,6 +5,7 @@ import { Fragment } from 'react/jsx-runtime'
 import { type OsmRenderMapProps } from '../../types'
 import { useMapStyleRef } from '../map/style'
 import { type V } from '../tuple'
+import { useLayoutStyleRef, useZoomStyleRef } from '../viewer/layout/style'
 import { entryToVs } from './point'
 import { type RenderMapSymbolsProps } from './types'
 
@@ -14,26 +15,33 @@ export function RenderMapSymbols(
   const ref = useRef<SVGGElement>(null)
 
   useMapStyleRef(ref, 'map-symbols')
+  useLayoutStyleRef(ref, 'map-symbols')
+  useZoomStyleRef(ref, 'map-symbols')
 
   return (
     <g ref={ref} className="map-symbols">
       {props.mapSymbols.map((entry, i) => {
         return (
           <Fragment key={i}>
-            <g className={entry.name}>
-              <RenderUses
-                name={entry.name}
-                href={entry.href}
-                vs={entryToVs(props.data.mapData, entry)}
-                m={props.m}
-              />
-            </g>
+            <RenderUses
+              name={entry.name}
+              href={entry.href}
+              vs={entryToVs(props.data.mapData, entry)}
+              m={props.m}
+            />
           </Fragment>
         )
       })}
+      <style>{style}</style>
     </g>
   )
 }
+
+const style = `
+.map-symbols {
+  --zoom-s-inv-symbols: var(--zoom-s-inv);
+}
+`
 
 export function RenderUses(
   props: Readonly<{ name: string; href: string; vs: V[]; m: DOMMatrixReadOnly }>
@@ -45,12 +53,15 @@ export function RenderUses(
         .map(({ x, y }, j) => (
           <use
             key={j}
-            className={`${props.name}-${j}`}
+            className={`${props.name} ${props.name}-${j}`}
             href={props.href}
             style={{
               transform:
                 `translate(${x}px, ${y}px)`.replaceAll(/([.]\d\d)\d*/g, '$1') +
-                `scale(var(--map-symbol-size))`,
+                `scale(var(--zoom-s-inv-symbols))` +
+                //`scale(calc(var(--layout-fontsize) * var(--layout-svgscale) * var(--map-symbol-size-k))`,
+                //`scale(calc(var(--layout-fontsize) * var(--layout-svgscale) * var(--map-symbol-size-k) / 72))`,
+                `scale(calc(var(--layout-fontsize) * 1.5 * var(--layout-svgscale) / 72))`,
             }}
           />
         ))}

--- a/packages/lib/src/lib/carto/symbols.tsx
+++ b/packages/lib/src/lib/carto/symbols.tsx
@@ -5,7 +5,12 @@ import { Fragment } from 'react/jsx-runtime'
 import { type OsmRenderMapProps } from '../../types'
 import { useMapStyleRef } from '../map/style'
 import { type V } from '../tuple'
-import { useLayoutStyleRef, useZoomSStyleRef } from '../viewer/layout/style'
+import { trunc2 } from '../utils'
+import {
+  useLayoutStyleRef,
+  useSvgScaleStyleRef,
+  useZoomSStyleRef,
+} from '../viewer/layout/style'
 import { entryToVs } from './point'
 import { type RenderMapSymbolsProps } from './types'
 
@@ -15,8 +20,8 @@ export function RenderMapSymbols(
   const ref = useRef<SVGGElement>(null)
 
   useMapStyleRef(ref, 'map-symbols')
-  useLayoutStyleRef(ref, 'map-symbols')
   useZoomSStyleRef(ref, 'map-symbols')
+  useSvgScaleStyleRef(ref, 'map-symbols')
 
   return (
     <g ref={ref} className="map-symbols">
@@ -37,6 +42,35 @@ export function RenderMapSymbols(
   )
 }
 
+export function RenderMapSymbols2(
+  props: Readonly<OsmRenderMapProps & RenderMapSymbolsProps>
+): ReactNode {
+  const ref = useRef(null)
+
+  //useMapStyleRef(ref, 'map-symbols')
+  useZoomSStyleRef(ref, 'map-symbols')
+  useLayoutStyleRef(ref, 'map-symbols')
+  useSvgScaleStyleRef(ref, 'map-symbols')
+
+  return (
+    <div ref={ref} className="map-symbols content-html">
+      {props.mapSymbols.map((entry, i) => {
+        return (
+          <Fragment key={i}>
+            <RenderUses2
+              name={entry.name}
+              href={entry.href}
+              vs={entryToVs(props.data.mapData, entry)}
+              m={props.m}
+            />
+          </Fragment>
+        )
+      })}
+      <style>{style}</style>
+    </div>
+  )
+}
+
 // XXX
 // XXX
 // XXX
@@ -50,6 +84,7 @@ export function RenderMapSymbols(
 // XXX
 
 const style = `
+/*
 .map-symbols {
   & > .map-symbol {
     transform:
@@ -88,6 +123,7 @@ const style = `
       translate3d(0,0,0);
   }
 }
+*/
 `
 
 export function RenderUses(
@@ -106,9 +142,38 @@ export function RenderUses(
               {
                 '--map-symbol-x': `${x}px`.replaceAll(/([.]\d\d)\d*/g, '$1'),
                 '--map-symbol-y': `${y}px`.replaceAll(/([.]\d\d)\d*/g, '$1'),
+                display: j % 10 === 0 ? null : 'none',
               } as CSSProperties
             }
           />
+        ))}
+    </>
+  )
+}
+
+export function RenderUses2(
+  props: Readonly<{ name: string; href: string; vs: V[]; m: DOMMatrixReadOnly }>
+): ReactNode {
+  return (
+    <>
+      {props.vs
+        .map(([x, y]) => props.m.transformPoint({ x, y }))
+        .map(({ x, y }, j) => (
+          <div
+            key={j}
+            className={`map-symbol ${props.name} ${props.name}-${j}`}
+            style={
+              {
+                '--poi-x': `${trunc2(x)}px`,
+                '--poi-y': `${trunc2(y)}px`,
+                display: j % 5 === 0 ? null : 'none',
+              } as CSSProperties
+            }
+          >
+            <svg viewBox="-36 -36 72 72" width="72" height="72">
+              <use href={props.href} />
+            </svg>
+          </div>
         ))}
     </>
   )

--- a/packages/lib/src/lib/carto/symbols.tsx
+++ b/packages/lib/src/lib/carto/symbols.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable functional/no-expression-statements */
-import { useRef, type ReactNode } from 'react'
+import { useRef, type CSSProperties, type ReactNode } from 'react'
 import { Fragment } from 'react/jsx-runtime'
 
 import { type OsmRenderMapProps } from '../../types'
 import { useMapStyleRef } from '../map/style'
 import { type V } from '../tuple'
-import { useLayoutStyleRef, useZoomStyleRef } from '../viewer/layout/style'
+import { useLayoutStyleRef, useZoomSStyleRef } from '../viewer/layout/style'
 import { entryToVs } from './point'
 import { type RenderMapSymbolsProps } from './types'
 
@@ -16,7 +16,7 @@ export function RenderMapSymbols(
 
   useMapStyleRef(ref, 'map-symbols')
   useLayoutStyleRef(ref, 'map-symbols')
-  useZoomStyleRef(ref, 'map-symbols')
+  useZoomSStyleRef(ref, 'map-symbols')
 
   return (
     <g ref={ref} className="map-symbols">
@@ -39,7 +39,35 @@ export function RenderMapSymbols(
 
 const style = `
 .map-symbols {
-  --zoom-s-inv-symbols: var(--zoom-s-inv);
+  & > .map-symbol {
+    translate: var(--map-symbol-x) var(--map-symbol-y);
+    scale: calc(var(--layout-fontsize) * 1.5 * var(--layout-svgscale) / 72);
+  }
+  &.zooming {
+    & > .map-symbol {
+      will-change: scale;
+      animation: xxx-map-symbol 500ms ease;
+    }
+  }
+}
+@keyframes xxx-map-symbol {
+  from {
+    scale:
+      calc(
+        var(--layout-fontsize) *
+        1.5 *
+        var(--layout-svgscale) /
+        72);
+  }
+  to {
+    scale:
+      calc(
+        1 / var(--zoom-s) *
+        var(--layout-fontsize) *
+        1.5 *
+        var(--layout-svgscale) /
+        72);
+  }
 }
 `
 
@@ -53,16 +81,14 @@ export function RenderUses(
         .map(({ x, y }, j) => (
           <use
             key={j}
-            className={`${props.name} ${props.name}-${j}`}
+            className={`map-symbol ${props.name} ${props.name}-${j}`}
             href={props.href}
-            style={{
-              transform:
-                `translate(${x}px, ${y}px)`.replaceAll(/([.]\d\d)\d*/g, '$1') +
-                `scale(var(--zoom-s-inv-symbols))` +
-                //`scale(calc(var(--layout-fontsize) * var(--layout-svgscale) * var(--map-symbol-size-k))`,
-                //`scale(calc(var(--layout-fontsize) * var(--layout-svgscale) * var(--map-symbol-size-k) / 72))`,
-                `scale(calc(var(--layout-fontsize) * 1.5 * var(--layout-svgscale) / 72))`,
-            }}
+            style={
+              {
+                '--map-symbol-x': `${x}px`.replaceAll(/([.]\d\d)\d*/g, '$1'),
+                '--map-symbol-y': `${y}px`.replaceAll(/([.]\d\d)\d*/g, '$1'),
+              } as CSSProperties
+            }
           />
         ))}
     </>

--- a/packages/lib/src/lib/carto/types.ts
+++ b/packages/lib/src/lib/carto/types.ts
@@ -42,7 +42,7 @@ export interface RenderMapMarkersProps {
   readonly m: DOMMatrixReadOnly
   readonly mapMarkers: readonly OsmMapMarkers[]
   readonly fontSize: number
-  readonly s: number
+  //readonly s: number
 }
 
 export interface MapMarker {

--- a/packages/lib/src/lib/css/index.ts
+++ b/packages/lib/src/lib/css/index.ts
@@ -113,7 +113,7 @@ cubic-bezier(1, 0, 1, 1)
 //// animation
 
 export const ZOOM_DURATION_DETAIL = 400
-export const ZOOM_DURATION_HEADER = 300
+export const ZOOM_DURATION_HEADER = 400
 
 export const floor_switch_duration = '250ms'
 

--- a/packages/lib/src/lib/css/property.ts
+++ b/packages/lib/src/lib/css/property.ts
@@ -61,57 +61,62 @@ export const propertiesStyle = `
 }
 @property --a {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 1;
 }
 @property --b {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 1;
 }
 @property --balloon-opacity {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 1;
 }
 @property --balloon-translate-x {
   syntax: '<length>';
-  inherits: true;
+  inherits: false;
   initial-value: 0;
 }
 @property --balloon-translate-y {
   syntax: '<length>';
-  inherits: true;
+  inherits: false;
   initial-value: 0;
 }
 @property --balloon-scale {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 1;
 }
-@property --header-scale {
-  syntax: '<number>';
-  inherits: true;
-  initial-value: 1;
+@property --pww {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
 }
-@property --footer-scale {
-  syntax: '<number>';
-  inherits: true;
-  initial-value: 1;
+@property --phh {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
 }
-@property --left-scale {
-  syntax: '<number>';
-  inherits: true;
-  initial-value: 1;
+@property --tx-a-x {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
 }
-@property --right-scale {
-  syntax: '<number>';
-  inherits: true;
-  initial-value: 1;
+@property --tx-a-y {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
 }
-@property --screen-opacity {
-  syntax: '<number>';
-  inherits: true;
+@property --tx-b-x {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --tx-b-y {
+  syntax: '<length>';
+  inherits: false;
   initial-value: 0;
 }
 @property --layout-container-width {
@@ -123,6 +128,16 @@ export const propertiesStyle = `
   syntax: '<length>';
   inherits: false;
   initial-value: 0;
+}
+@property --layout-content-matrix {
+  syntax: "*";
+  inherits: false;
+  initial-value: matrix(1, 0, 0, 1, 0, 0);
+}
+@property --layout-svg-to-content-matrix {
+  syntax: "*";
+  inherits: false;
+  initial-value: matrix(1, 0, 0, 1, 0, 0);
 }
 @property --layout-scroll-width {
   syntax: '<length>';

--- a/packages/lib/src/lib/css/property.ts
+++ b/packages/lib/src/lib/css/property.ts
@@ -114,4 +114,34 @@ export const propertiesStyle = `
   inherits: true;
   initial-value: 0;
 }
+@property --layout-container-width {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-container-height {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-scroll-width {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-scroll-height {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+@property --layout-svgscale {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --layout-fontsize {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 16;
+}
 `

--- a/packages/lib/src/lib/css/property.ts
+++ b/packages/lib/src/lib/css/property.ts
@@ -136,12 +136,12 @@ export const propertiesStyle = `
 }
 @property --layout-svgscale {
   syntax: '<number>';
-  inherits: false;
+  inherits: true;
   initial-value: 1;
 }
 @property --layout-fontsize {
   syntax: '<number>';
-  inherits: false;
+  inherits: true;
   initial-value: 16;
 }
 `

--- a/packages/lib/src/lib/css/property.ts
+++ b/packages/lib/src/lib/css/property.ts
@@ -1,3 +1,4 @@
+export const properties = `
 @property --a {
   syntax: '<number>';
   inherits: false;
@@ -183,3 +184,4 @@
   inherits: false;
   initial-value: 1;
 }
+`

--- a/packages/lib/src/lib/css/property.ts
+++ b/packages/lib/src/lib/css/property.ts
@@ -1,30 +1,55 @@
 export const propertiesStyle = `
+@property --zoom-origin {
+  syntax: "<length-percentage>+";
+  inherits: false;
+  initial-value: 0% 0%;
+}
+@property --zoom-zoom {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
 @property --zoom-tx {
   syntax: '<length>';
-  inherits: true;
+  inherits: false;
   initial-value: 0;
 }
 @property --zoom-ty {
   syntax: '<length>';
-  inherits: true;
+  inherits: false;
   initial-value: 0;
 }
 @property --zoom-s {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 1;
 }
 @property --zoom-s-inv {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 1;
 }
 @property --zoom-z {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 1;
 }
 @property --zoom-z-inv {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --zoom-k {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --zoom-k-inv {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 1;
+}
+@property --zoom-s-inv-symbols {
   syntax: '<number>';
   inherits: true;
   initial-value: 1;

--- a/packages/lib/src/lib/css/property.ts
+++ b/packages/lib/src/lib/css/property.ts
@@ -24,6 +24,11 @@ export const propertiesStyle = `
   inherits: false;
   initial-value: 1;
 }
+@property --zoom-s-symbols {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 1;
+}
 @property --zoom-s-inv {
   syntax: '<number>';
   inherits: false;

--- a/packages/lib/src/lib/map/Map.tsx
+++ b/packages/lib/src/lib/map/Map.tsx
@@ -6,7 +6,9 @@ import { RenderMapCommon } from '../carto'
 import { isShadowRootRendered } from '../dom'
 import { MAP_SVG_PATHS_ROOT_ID } from './map-svg-react'
 import { MapHtml } from './MapHtml'
+/*
 import { MapSvgLabels } from './MapSvgLabels'
+*/
 import { MapSvgMarkers } from './MapSvgMarkers'
 import { MapSvgObjects } from './MapSvgObjects'
 import { MapSvgPaths } from './MapSvgPaths'
@@ -25,7 +27,9 @@ export function RenderMapOsmDefault(
       <MapSvgObjects {...props} />
       <MapSvgSymbols {...props} />
       <MapSvgMarkers {...props} />
+      {/*
       <MapSvgLabels {...props} />
+      */}
       <MapHtml {...props} />
     </>
   )

--- a/packages/lib/src/lib/map/Map.tsx
+++ b/packages/lib/src/lib/map/Map.tsx
@@ -12,7 +12,9 @@ import { MapSvgLabels } from './MapSvgLabels'
 import { MapSvgMarkers } from './MapSvgMarkers'
 import { MapSvgObjects } from './MapSvgObjects'
 import { MapSvgPaths } from './MapSvgPaths'
+/*
 import { MapSvgSymbols } from './MapSvgSymbols'
+*/
 
 export function OsmRenderMap(props: Readonly<OsmRenderMapProps>): ReactNode {
   return RenderMapCommon(props)
@@ -25,7 +27,9 @@ export function RenderMapOsmDefault(
     <>
       <MapSvgPaths {...props} />
       <MapSvgObjects {...props} />
+      {/*
       <MapSvgSymbols {...props} />
+      */}
       <MapSvgMarkers {...props} />
       {/*
       <MapSvgLabels {...props} />

--- a/packages/lib/src/lib/map/MapHtml.tsx
+++ b/packages/lib/src/lib/map/MapHtml.tsx
@@ -36,7 +36,7 @@ const style = `
   width: var(--layout-scroll-width);
   height: var(--layout-scroll-height);
   transform: var(--layout-svg-to-content-matrix);
-  transform-origin: left top;
+  transform-origin: 0% 0%;
 }
 
 .stroke {
@@ -67,7 +67,7 @@ function MapHtmlPointNames(
               left: 0,
               top: 0,
               transform: `translate(${poi.coord.x}px, ${poi.coord.y}px) scale(0.025) translate(-50%, -50%)`,
-              transformOrigin: 'left top',
+              transformOrigin: '0% 0%',
             }}
           >
             {(typeof poi.name === 'string' ? [poi.name] : poi.name).map(

--- a/packages/lib/src/lib/map/MapHtml.tsx
+++ b/packages/lib/src/lib/map/MapHtml.tsx
@@ -21,7 +21,17 @@ export function MapHtml(props: Readonly<OsmRenderMapProps>): ReactNode {
   useLayoutStyleRef(ref, 'map-html-root')
   useShadowRoot(MAP_HTML_ROOT_ID, <MapHtmlRoot {...props} />)
 
-  return <div ref={ref} id={MAP_HTML_ROOT_ID} className="content svg" />
+  return (
+    <div
+      ref={ref}
+      id={MAP_HTML_ROOT_ID}
+      className="content svg"
+      style={{
+        contain: 'strict',
+        contentVisibility: 'auto',
+      }}
+    />
+  )
 }
 
 function MapHtmlRoot(props: Readonly<OsmRenderMapProps>): ReactNode {

--- a/packages/lib/src/lib/map/MapHtml.tsx
+++ b/packages/lib/src/lib/map/MapHtml.tsx
@@ -52,7 +52,7 @@ const style = `
   top: 0;
   width: var(--layout-scroll-width);
   height: var(--layout-scroll-height);
-  transform: var(--layout-svg-to-content-matrix) translateZ(0);
+  transform: var(--layout-svg-to-content-matrix);
   transform-origin: 0% 0%;
   &.zooming {
     & > .map-symbol,
@@ -79,7 +79,6 @@ const style = `
   position: absolute;
   left: 0;
   top: 0;
-  will-change: transform;
   transform-origin: 0% 0%;
   transform:
     translate(var(--poi-x), var(--poi-y))
@@ -102,7 +101,6 @@ const style = `
   z-index: -1;
   background-color: rgba(255, 255, 255, 0.5);
   border-radius: 50%;
-  will-change: transform, width, height; 
   transform: translate(-50%, calc(-50% + 0.75em));
 }
 svg {

--- a/packages/lib/src/lib/map/MapHtml.tsx
+++ b/packages/lib/src/lib/map/MapHtml.tsx
@@ -45,6 +45,14 @@ function MapHtmlRoot(props: Readonly<OsmRenderMapProps>): ReactNode {
   )
 }
 
+// XXX
+// XXX
+// XXX
+// XXX fix 'contain'
+// XXX
+// XXX
+// XXX
+
 const style = `
 .content-html {
   position: absolute;

--- a/packages/lib/src/lib/map/MapHtml.tsx
+++ b/packages/lib/src/lib/map/MapHtml.tsx
@@ -52,7 +52,7 @@ const style = `
   top: 0;
   width: var(--layout-scroll-width);
   height: var(--layout-scroll-height);
-  transform: var(--layout-svg-to-content-matrix);
+  transform: var(--layout-svg-to-content-matrix) translateZ(0);
   transform-origin: 0% 0%;
   &.zooming {
     & > .map-symbol,
@@ -66,6 +66,12 @@ const style = `
   text-stroke: 3px white;
   -webkit-text-stroke: 3px white;
 }
+.label {
+  --poi-scale: 0.05;
+}
+.map-symbol {
+  --poi-scale: 0.02;
+}
 .map-symbol,
 .label {
   color: black;
@@ -73,6 +79,7 @@ const style = `
   position: absolute;
   left: 0;
   top: 0;
+  will-change: transform;
   transform-origin: 0% 0%;
   transform:
     translate(var(--poi-x), var(--poi-y))
@@ -80,10 +87,9 @@ const style = `
       calc(
         var(--layout-fontsize) *
         var(--layout-svgscale) *
-        0.05)
+        var(--poi-scale))
       )
-    translate(-50%, -50%)
-    translateZ(0);
+    translate(-50%, -50%);
 }
 .label::before {
   content: "";
@@ -110,10 +116,9 @@ svg {
         calc(
           var(--layout-fontsize) *
           var(--layout-svgscale) *
-          0.05)
+          var(--poi-scale))
         )
-      translate(-50%, -50%)
-      translateZ(0);
+      translate(-50%, -50%);
   }
   to {
     transform:
@@ -123,10 +128,9 @@ svg {
           1 / var(--zoom-s-symbols) *
           var(--layout-fontsize) *
           var(--layout-svgscale) *
-          0.05)
+          var(--poi-scale))
         )
-      translate(-50%, -50%)
-      translateZ(0);
+      translate(-50%, -50%);
   }
 }
 `

--- a/packages/lib/src/lib/map/MapHtml.tsx
+++ b/packages/lib/src/lib/map/MapHtml.tsx
@@ -1,35 +1,52 @@
+/* eslint-disable functional/functional-parameters */
 /* eslint-disable functional/no-expression-statements */
 
-import { useRef, type ReactNode } from 'react'
+import { useRef, type CSSProperties, type ReactNode } from 'react'
 
 import { type OsmRenderMapProps } from '../../types'
+import { RenderMapAssetsDefault } from '../carto/assets'
+import { RenderMapSymbols2 } from '../carto/symbols'
 import { useShadowRoot } from '../dom'
-import { useLayoutStyleRef } from '../viewer/layout/style'
+import { trunc2 } from '../utils'
+import {
+  useLayoutStyleRef,
+  useSvgScaleStyleRef,
+  useZoomSStyleRef,
+} from '../viewer/layout/style'
 import { MAP_HTML_CONTENT_ID, MAP_HTML_ROOT_ID } from './map-svg-react'
 import { useNames } from './names'
 
 export function MapHtml(props: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutStyleRef(ref, 'map-html-root')
   useShadowRoot(MAP_HTML_ROOT_ID, <MapHtmlRoot {...props} />)
 
-  return <div id={MAP_HTML_ROOT_ID} className="content svg" />
+  return <div ref={ref} id={MAP_HTML_ROOT_ID} className="content svg" />
 }
 
 function MapHtmlRoot(props: Readonly<OsmRenderMapProps>): ReactNode {
   const ref = useRef(null)
+  useZoomSStyleRef(ref, 'map-html')
   useLayoutStyleRef(ref, 'map-html')
+  useSvgScaleStyleRef(ref, 'map-html')
   return (
     <>
-      <div ref={ref} id={MAP_HTML_CONTENT_ID} className="content-html">
-        <MapHtmlPointNames {...props} stroke={true} />
+      <div ref={ref} id={MAP_HTML_CONTENT_ID} className="content-html labels">
         <MapHtmlPointNames {...props} />
       </div>
+      <MapSvgSymbolsDefs />
+      <RenderMapSymbols2
+        {...props}
+        m={props.data.mapCoord.matrix}
+        mapSymbols={props.render.getMapSymbols()}
+      />
       <style>{style}</style>
     </>
   )
 }
 
 const style = `
-#map-html-content {
+.content-html {
   position: absolute;
   left: 0;
   top: 0;
@@ -37,11 +54,80 @@ const style = `
   height: var(--layout-scroll-height);
   transform: var(--layout-svg-to-content-matrix);
   transform-origin: 0% 0%;
+  &.zooming {
+    & > .map-symbol,
+    & > .label {
+      will-change: transform;
+      animation: xxx-label 500ms ease forwards;
+    }
+  }
 }
-
 .stroke {
   text-stroke: 3px white;
   -webkit-text-stroke: 3px white;
+}
+.map-symbol,
+.label {
+  color: black;
+  font-weight: bold;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform-origin: 0% 0%;
+  transform:
+    translate(var(--poi-x), var(--poi-y))
+    scale(
+      calc(
+        var(--layout-fontsize) *
+        var(--layout-svgscale) *
+        0.05)
+      )
+    translate(-50%, -50%)
+    translateZ(0);
+}
+.label::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 10em;
+  aspect-ratio: 1 / 1;
+  min-width: 20%;
+  min-height: 20%;
+  z-index: -1;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 50%;
+  will-change: transform, width, height; 
+  transform: translate(-50%, calc(-50% + 0.75em));
+}
+svg {
+  display: block;
+}
+@keyframes xxx-label {
+  from {
+    transform:
+      translate(var(--poi-x), var(--poi-y))
+      scale(
+        calc(
+          var(--layout-fontsize) *
+          var(--layout-svgscale) *
+          0.05)
+        )
+      translate(-50%, -50%)
+      translateZ(0);
+  }
+  to {
+    transform:
+      translate(var(--poi-x), var(--poi-y))
+      scale(
+        calc(
+          1 / var(--zoom-s-symbols) *
+          var(--layout-fontsize) *
+          var(--layout-svgscale) *
+          0.05)
+        )
+      translate(-50%, -50%)
+      translateZ(0);
+  }
 }
 `
 
@@ -62,13 +148,14 @@ function MapHtmlPointNames(
         .map((poi, idx) => (
           <div
             key={idx}
-            style={{
-              position: 'absolute',
-              left: 0,
-              top: 0,
-              transform: `translate(${poi.coord.x}px, ${poi.coord.y}px) scale(0.025) translate(-50%, -50%)`,
-              transformOrigin: '0% 0%',
-            }}
+            className="label"
+            style={
+              {
+                '--poi-x': `${trunc2(poi.coord.x)}px`,
+                '--poi-y': `${trunc2(poi.coord.y)}px`,
+                display: idx % 2 === 0 ? null : 'none',
+              } as CSSProperties
+            }
           >
             {(typeof poi.name === 'string' ? [poi.name] : poi.name).map(
               (s, idx2) => (
@@ -86,3 +173,23 @@ function MapHtmlPointNames(
     </>
   )
 }
+
+function MapSvgSymbolsDefs(): ReactNode {
+  return (
+    <svg id="map-svg-symbols-defs">
+      <g id="map-svg-symbols1">
+        <defs>
+          <RenderMapAssetsDefault />
+        </defs>
+      </g>
+    </svg>
+  )
+}
+
+/*
+        <RenderMapSymbols
+          {...props}
+          m={props.data.mapCoord.matrix}
+          mapSymbols={props.render.getMapSymbols()}
+        />
+*/

--- a/packages/lib/src/lib/map/MapSvgLabels.tsx
+++ b/packages/lib/src/lib/map/MapSvgLabels.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { Fragment, useMemo, type ReactNode } from 'react'
+import { Fragment, useMemo, useRef, type ReactNode } from 'react'
 
 import { type OsmRenderMapProps, type POI } from '../../types'
 import { boxToViewBox2 } from '../box/prefixed'
@@ -8,6 +8,7 @@ import { useShadowRoot } from '../dom'
 import { useLayout, useLayoutSvgScaleS } from '../style/style-react'
 import { voffset } from '../text'
 import { trunc2 } from '../utils'
+import { useLayoutStyleRef } from '../viewer/layout/style'
 import {
   MAP_SVG_LABELS_CONTENT_ID,
   MAP_SVG_LABELS_ROOT_ID,
@@ -15,9 +16,11 @@ import {
 import { useNameRanges, useNames } from './names'
 
 export function MapSvgLabels(props: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutStyleRef(ref, 'map-html-root')
   useShadowRoot(MAP_SVG_LABELS_ROOT_ID, <MapSvgLabelsRoot {...props} />)
 
-  return <div id={MAP_SVG_LABELS_ROOT_ID} className="content svg" />
+  return <div ref={ref} id={MAP_SVG_LABELS_ROOT_ID} className="content svg" />
 }
 
 export function MapSvgLabelsRoot(

--- a/packages/lib/src/lib/map/MapSvgMarkers.tsx
+++ b/packages/lib/src/lib/map/MapSvgMarkers.tsx
@@ -1,16 +1,19 @@
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { Fragment, type ReactNode } from 'react'
+import {
+  Fragment,
+  useMemo,
+  type PropsWithChildren,
+  type ReactNode,
+} from 'react'
 
 import { type OsmRenderMapProps } from '../../types'
 import { boxToViewBox2 } from '../box/prefixed'
 import { RenderMapMarkers } from '../carto'
+import { RenderMarkerUses } from '../carto/markers'
+import { entryToVs } from '../carto/point'
 import { useShadowRoot } from '../dom'
-import {
-  useLayout,
-  useLayoutConfig,
-  useLayoutSvgScaleS,
-} from '../style/style-react'
+import { useLayout, useLayoutConfig } from '../style/style-react'
 import { trunc2 } from '../utils'
 import { type VecVec } from '../vec/prefixed'
 import {
@@ -31,7 +34,12 @@ export function MapSvgMarkersRoot(
   return (
     <>
       <MapSvgMarkersSvg />
-      <MapSvgMarkersDefs {...props} />
+      <MapSvgMarkersDefs {...props}>
+        <g id="map-svg-markers1">
+          <MapSvgMarkersUses />
+          <use href="#position" />
+        </g>
+      </MapSvgMarkersDefs>
       <style>{style}</style>
     </>
   )
@@ -64,9 +72,11 @@ function MapSvgMarkersSvg(): ReactNode {
   )
 }
 
-function MapSvgMarkersDefs(props: Readonly<OsmRenderMapProps>): ReactNode {
+function MapSvgMarkersDefs(
+  props: Readonly<PropsWithChildren<OsmRenderMapProps>>
+): ReactNode {
   const { fontSize } = useLayoutConfig()
-  const s = useLayoutSvgScaleS()
+  const sz = useMemo(() => 25 / fontSize, [fontSize])
 
   return (
     <svg id="map-svg-markers-defs">
@@ -75,24 +85,31 @@ function MapSvgMarkersDefs(props: Readonly<OsmRenderMapProps>): ReactNode {
         m={props.data.mapCoord.matrix}
         mapMarkers={props.render.getMapMarkers()}
         fontSize={fontSize}
-        s={s}
-      />
-      <g id="map-svg-markers1">
-        <MapSvgMarkersUses {...props} />
-        <use href="#position" />
-      </g>
+      >
+        {props.render.getMapMarkers().map((entry, i) => (
+          <g key={i}>
+            <RenderMarkerUses
+              m={props.data.mapCoord.matrix}
+              sz={sz}
+              name={entry.name}
+              href={entry.name} // XXX XXX XXX
+              vs={entryToVs(props.data.mapData, entry)}
+            />
+          </g>
+        ))}
+      </RenderMapMarkers>
+      {props.children}
     </svg>
   )
 }
 
-function MapSvgMarkersUses(props: Readonly<OsmRenderMapProps>): ReactNode {
+function MapSvgMarkersUses(): ReactNode {
   const { pointNames } = useNames()
-  const m = props.data.mapCoord.matrix
 
   return (
     <g>
       {pointNames
-        .map((p) => ({ ...p, pos: m.transformPoint(p.coord) }))
+        .map((p) => ({ ...p }))
         .map(({ coord }, idx) => (
           <Fragment key={idx}>
             <MapSvgMarkersUse coord={coord} />

--- a/packages/lib/src/lib/map/MapSvgMarkers.tsx
+++ b/packages/lib/src/lib/map/MapSvgMarkers.tsx
@@ -3,6 +3,7 @@
 import {
   Fragment,
   useMemo,
+  useRef,
   type PropsWithChildren,
   type ReactNode,
 } from 'react'
@@ -13,9 +14,10 @@ import { RenderMapMarkers } from '../carto'
 import { RenderMarkerUses } from '../carto/markers'
 import { entryToVs } from '../carto/point'
 import { useShadowRoot } from '../dom'
-import { useLayout, useLayoutConfig } from '../style/style-react'
+import { useLayoutConfig, useLayoutSvg } from '../style/style-react'
 import { trunc2 } from '../utils'
 import { type VecVec } from '../vec/prefixed'
+import { useLayoutStyleRef } from '../viewer/layout/style'
 import {
   MAP_SVG_MARKERS_CONTENT_ID,
   MAP_SVG_MARKERS_ROOT_ID,
@@ -57,29 +59,37 @@ const style = `
 `
 
 function MapSvgMarkersSvg(): ReactNode {
-  const { scroll, svg } = useLayout()
+  const svg = useLayoutSvg()
 
   return (
     <svg
       id={MAP_SVG_MARKERS_CONTENT_ID}
       className="content-svg"
       viewBox={boxToViewBox2(svg)}
-      width={trunc2(scroll.width)}
-      height={trunc2(scroll.height)}
     >
       <use href="#map-svg-markers1" />
+      <style>{style1}</style>
     </svg>
   )
 }
 
+const style1 = `
+#${MAP_SVG_MARKERS_CONTENT_ID} {
+  width: var(--layout-scroll-width);
+  height: var(--layout-scroll-height);
+}`
+
 function MapSvgMarkersDefs(
   props: Readonly<PropsWithChildren<OsmRenderMapProps>>
 ): ReactNode {
+  const ref = useRef(null)
   const { fontSize } = useLayoutConfig()
   const sz = useMemo(() => 25 / fontSize, [fontSize])
 
+  useLayoutStyleRef(ref, 'map-svg-markers')
+
   return (
-    <svg id="map-svg-markers-defs">
+    <svg ref={ref} id="map-svg-markers-defs">
       <RenderMapMarkers
         {...props}
         m={props.data.mapCoord.matrix}

--- a/packages/lib/src/lib/map/MapSvgMarkers.tsx
+++ b/packages/lib/src/lib/map/MapSvgMarkers.tsx
@@ -25,9 +25,11 @@ import {
 import { useNames } from './names'
 
 export function MapSvgMarkers(props: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef(null)
+  useLayoutStyleRef(ref, 'map-svg-markers-root')
   useShadowRoot(MAP_SVG_MARKERS_ROOT_ID, <MapSvgMarkersRoot {...props} />)
 
-  return <div id={MAP_SVG_MARKERS_ROOT_ID} className="content svg" />
+  return <div ref={ref} id={MAP_SVG_MARKERS_ROOT_ID} className="content svg" />
 }
 
 export function MapSvgMarkersRoot(

--- a/packages/lib/src/lib/map/MapSvgObjects.tsx
+++ b/packages/lib/src/lib/map/MapSvgObjects.tsx
@@ -1,21 +1,25 @@
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { type ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
 
 import { type OsmRenderMapProps } from '../../types'
 import { boxToViewBox2 } from '../box/prefixed'
 import { RenderMapObjects } from '../carto'
 import { useShadowRoot } from '../dom'
-import { useLayoutSvg } from '../style/style-react'
+import { useLayout } from '../style/style-react'
+import { trunc2 } from '../utils'
+import { useLayoutStyleRef } from '../viewer/layout/style'
 import {
   MAP_SVG_OBJECTS_CONTENT_ID,
   MAP_SVG_OBJECTS_ROOT_ID,
 } from './map-svg-react'
 
 export function MapSvgObjects(props: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutStyleRef(ref, 'map-svg-objects-root')
   useShadowRoot(MAP_SVG_OBJECTS_ROOT_ID, <MapSvgObjectsRoot {...props} />)
 
-  return <div id={MAP_SVG_OBJECTS_ROOT_ID} className="content svg" />
+  return <div ref={ref} id={MAP_SVG_OBJECTS_ROOT_ID} className="content svg" />
 }
 
 export function MapSvgObjectsRoot(
@@ -42,26 +46,20 @@ const style = `
 `
 
 function MapSvgObjectsSvg(): ReactNode {
-  const svg = useLayoutSvg()
+  const { scroll, svg } = useLayout()
 
   return (
     <svg
       id={MAP_SVG_OBJECTS_CONTENT_ID}
       className="content-svg"
       viewBox={boxToViewBox2(svg)}
+      width={trunc2(scroll.width)}
+      height={trunc2(scroll.height)}
     >
       <use href="#map-svg-objects1" />
-      <style>{style1}</style>
     </svg>
   )
 }
-
-const style1 = `
-#${MAP_SVG_OBJECTS_CONTENT_ID} {
-  width: var(--layout-scroll-width);
-  height: var(--layout-scroll-height);
-}
-`
 
 function MapSvgObjectsDefs(props: Readonly<OsmRenderMapProps>): ReactNode {
   return (

--- a/packages/lib/src/lib/map/MapSvgObjects.tsx
+++ b/packages/lib/src/lib/map/MapSvgObjects.tsx
@@ -6,8 +6,7 @@ import { type OsmRenderMapProps } from '../../types'
 import { boxToViewBox2 } from '../box/prefixed'
 import { RenderMapObjects } from '../carto'
 import { useShadowRoot } from '../dom'
-import { useLayout } from '../style/style-react'
-import { trunc2 } from '../utils'
+import { useLayoutSvg } from '../style/style-react'
 import {
   MAP_SVG_OBJECTS_CONTENT_ID,
   MAP_SVG_OBJECTS_ROOT_ID,
@@ -43,20 +42,26 @@ const style = `
 `
 
 function MapSvgObjectsSvg(): ReactNode {
-  const { scroll, svg } = useLayout()
+  const svg = useLayoutSvg()
 
   return (
     <svg
       id={MAP_SVG_OBJECTS_CONTENT_ID}
       className="content-svg"
       viewBox={boxToViewBox2(svg)}
-      width={trunc2(scroll.width)}
-      height={trunc2(scroll.height)}
     >
       <use href="#map-svg-objects1" />
+      <style>{style1}</style>
     </svg>
   )
 }
+
+const style1 = `
+#${MAP_SVG_OBJECTS_CONTENT_ID} {
+  width: var(--layout-scroll-width);
+  height: var(--layout-scroll-height);
+}
+`
 
 function MapSvgObjectsDefs(props: Readonly<OsmRenderMapProps>): ReactNode {
   return (

--- a/packages/lib/src/lib/map/MapSvgPaths.tsx
+++ b/packages/lib/src/lib/map/MapSvgPaths.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { type ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
 
 import { type OsmRenderMapProps } from '../../types'
 import { boxToViewBox2 } from '../box/prefixed'
@@ -8,15 +8,18 @@ import { RenderMapPaths } from '../carto'
 import { useShadowRoot } from '../dom'
 import { useLayout } from '../style/style-react'
 import { trunc2 } from '../utils'
+import { useLayoutStyleRef } from '../viewer/layout/style'
 import {
   MAP_SVG_PATHS_CONTENT_ID,
   MAP_SVG_PATHS_ROOT_ID,
 } from './map-svg-react'
 
 export function MapSvgPaths(props: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutStyleRef(ref, 'map-svg-paths-root')
   useShadowRoot(MAP_SVG_PATHS_ROOT_ID, <MapSvgPathsRoot {...props} />)
 
-  return <div id={MAP_SVG_PATHS_ROOT_ID} className="content svg" />
+  return <div ref={ref} id={MAP_SVG_PATHS_ROOT_ID} className="content svg" />
 }
 
 export function MapSvgPathsRoot(props: Readonly<OsmRenderMapProps>): ReactNode {

--- a/packages/lib/src/lib/map/MapSvgSymbols.tsx
+++ b/packages/lib/src/lib/map/MapSvgSymbols.tsx
@@ -16,9 +16,11 @@ import {
 } from './map-svg-react'
 
 export function MapSvgSymbols(props: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutStyleRef(ref, 'map-svg-symbols-root')
   useShadowRoot(MAP_SVG_SYMBOLS_ROOT_ID, <MapSvgSymbolsRoot {...props} />)
 
-  return <div id={MAP_SVG_SYMBOLS_ROOT_ID} className="content svg" />
+  return <div ref={ref} id={MAP_SVG_SYMBOLS_ROOT_ID} className="content svg" />
 }
 
 export function MapSvgSymbolsRoot(

--- a/packages/lib/src/lib/map/MapSvgSymbols.tsx
+++ b/packages/lib/src/lib/map/MapSvgSymbols.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { type ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
 
 import { type OsmRenderMapProps } from '../../types'
 import { boxToViewBox2 } from '../box/prefixed'
@@ -9,6 +9,7 @@ import { RenderMapAssetsDefault } from '../carto/assets'
 import { useShadowRoot } from '../dom'
 import { useLayout } from '../style/style-react'
 import { trunc2 } from '../utils'
+import { useLayoutStyleRef } from '../viewer/layout/style'
 import {
   MAP_SVG_SYMBOLS_CONTENT_ID,
   MAP_SVG_SYMBOLS_ROOT_ID,
@@ -60,8 +61,10 @@ function MapSvgSymbolsSvg(): ReactNode {
 }
 
 function MapSvgSymbolsDefs(props: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef(null)
+  useLayoutStyleRef(ref, 'map-svg-symbols')
   return (
-    <svg id="map-svg-symbols-defs">
+    <svg ref={ref} id="map-svg-symbols-defs">
       <g id="map-svg-symbols1">
         <defs>
           <RenderMapAssetsDefault />

--- a/packages/lib/src/lib/map/floors/FloorsHtml.tsx
+++ b/packages/lib/src/lib/map/floors/FloorsHtml.tsx
@@ -17,16 +17,18 @@ export function RenderFloorsHtml({
   const ref = useRef(null)
   useLayoutStyleRef(ref, 'map-floors-html')
   return (
-    <div ref={ref} className="content map-floors-html">
-      {floors?.floors.map((floor, fidx) => (
-        <Fragment key={fidx}>
-          <RenderFloorHtml
-            fidx={fidx}
-            floor={floor}
-            labelsMap={floors?.labelsMap}
-          />
-        </Fragment>
-      ))}
+    <div className="content">
+      <div ref={ref} className="map-floors-html">
+        {floors?.floors.map((floor, fidx) => (
+          <Fragment key={fidx}>
+            <RenderFloorHtml
+              fidx={fidx}
+              floor={floor}
+              labelsMap={floors?.labelsMap}
+            />
+          </Fragment>
+        ))}
+      </div>
       <style>{htmlStyle}</style>
     </div>
   )

--- a/packages/lib/src/lib/map/floors/FloorsHtml.tsx
+++ b/packages/lib/src/lib/map/floors/FloorsHtml.tsx
@@ -11,25 +11,33 @@ import { useFloorRef } from '../../viewer/floors/style'
 import { useLayoutStyleRef } from '../../viewer/layout/style'
 import { RenderFloorLabels } from './FloorsHtmlLabels'
 
-export function RenderFloorsHtml({
+export function RenderFloorsHtml(
+  props: Readonly<OsmRenderMapProps>
+): ReactNode {
+  return (
+    <div className="content">
+      <RenderFloorsHtmlContent {...props} />
+      <style>{htmlStyle}</style>
+    </div>
+  )
+}
+
+function RenderFloorsHtmlContent({
   floors,
 }: Readonly<OsmRenderMapProps>): ReactNode {
   const ref = useRef(null)
   useLayoutStyleRef(ref, 'map-floors-html')
   return (
-    <div className="content">
-      <div ref={ref} className="map-floors-html">
-        {floors?.floors.map((floor, fidx) => (
-          <Fragment key={fidx}>
-            <RenderFloorHtml
-              fidx={fidx}
-              floor={floor}
-              labelsMap={floors?.labelsMap}
-            />
-          </Fragment>
-        ))}
-      </div>
-      <style>{htmlStyle}</style>
+    <div ref={ref} className="map-floors-html">
+      {floors?.floors.map((floor, fidx) => (
+        <Fragment key={fidx}>
+          <RenderFloorHtml
+            fidx={fidx}
+            floor={floor}
+            labelsMap={floors?.labelsMap}
+          />
+        </Fragment>
+      ))}
     </div>
   )
 }

--- a/packages/lib/src/lib/map/floors/FloorsHtml.tsx
+++ b/packages/lib/src/lib/map/floors/FloorsHtml.tsx
@@ -39,7 +39,7 @@ const htmlStyle = `
   width: var(--layout-scroll-width);
   height: var(--layout-scroll-height);
   transform: var(--layout-svg-to-content-matrix) !important;
-  transform-origin: left top !important;
+  transform-origin: 0% 0% !important;
 }
 `
 

--- a/packages/lib/src/lib/map/floors/FloorsHtml.tsx
+++ b/packages/lib/src/lib/map/floors/FloorsHtml.tsx
@@ -8,24 +8,25 @@ import {
   type OsmRenderMapProps,
 } from '../../../types'
 import { useFloorRef } from '../../viewer/floors/style'
+import { useLayoutStyleRef } from '../../viewer/layout/style'
 import { RenderFloorLabels } from './FloorsHtmlLabels'
 
 export function RenderFloorsHtml({
   floors,
 }: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef(null)
+  useLayoutStyleRef(ref, 'map-floors-html')
   return (
-    <div className="content">
-      <div className="map-floors-html">
-        {floors?.floors.map((floor, fidx) => (
-          <Fragment key={fidx}>
-            <RenderFloorHtml
-              fidx={fidx}
-              floor={floor}
-              labelsMap={floors?.labelsMap}
-            />
-          </Fragment>
-        ))}
-      </div>
+    <div ref={ref} className="content map-floors-html">
+      {floors?.floors.map((floor, fidx) => (
+        <Fragment key={fidx}>
+          <RenderFloorHtml
+            fidx={fidx}
+            floor={floor}
+            labelsMap={floors?.labelsMap}
+          />
+        </Fragment>
+      ))}
       <style>{htmlStyle}</style>
     </div>
   )

--- a/packages/lib/src/lib/map/floors/FloorsHtmlLabels.tsx
+++ b/packages/lib/src/lib/map/floors/FloorsHtmlLabels.tsx
@@ -54,7 +54,7 @@ div.labels {
 }
 div.label {
   position: absolute;
-  transform-origin: left top;
+  transform-origin: 0% 0%;
   /*
   transform: translate(var(--x), var(--y)) rotate(var(--rotate)) scale(var(--zoom-z-inv)) scale(var(--scale2)) scale(var(--scale1)) translate(-50%, -50%);
   */

--- a/packages/lib/src/lib/map/floors/FloorsSvg.tsx
+++ b/packages/lib/src/lib/map/floors/FloorsSvg.tsx
@@ -44,11 +44,18 @@ ${floor_appearing_animation}
 `
 
 function RenderFloorsSvgSvg(props: Readonly<PropsWithChildren>): ReactNode {
+  const ref = useRef(null)
   const { viewBox } = useLayout2()
+  useLayoutStyleRef(ref, `floors-svg`)
 
   // only this part is re-rendered after zoom (viewbox change)
   return (
-    <svg id={MAP_SVG_FLOORS} className="content-svg" viewBox={viewBox}>
+    <svg
+      ref={ref}
+      id={MAP_SVG_FLOORS}
+      className="content-svg"
+      viewBox={viewBox}
+    >
       {props.children}
     </svg>
   )

--- a/packages/lib/src/lib/map/floors/FloorsSvg.tsx
+++ b/packages/lib/src/lib/map/floors/FloorsSvg.tsx
@@ -10,6 +10,7 @@ import {
   type UseFloorsReturn,
 } from '../../viewer/floors/floors-react'
 import { useFloorRef } from '../../viewer/floors/style'
+import { useLayoutStyleRef } from '../../viewer/layout/style'
 import { MAP_SVG_FLOORS } from '../map-svg-react'
 import type { FloorProps } from './types'
 
@@ -17,9 +18,11 @@ export function RenderFloorsSvg({
   floors,
   data: { origViewBox },
 }: Readonly<OsmRenderMapProps>): ReactNode {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutStyleRef(ref, 'map-floors-svg')
   const ctx = useFloors()
   return (
-    <div className="content map-floors-svg">
+    <div ref={ref} className="content map-floors-svg">
       <RenderFloorsSvgSvg>
         {floors?.floors.map((_, fidx) => (
           <Fragment key={fidx}>

--- a/packages/lib/src/lib/map/style.ts
+++ b/packages/lib/src/lib/map/style.ts
@@ -14,17 +14,50 @@ export function useMapStyleRef(
   useStyleRef(mapStyleRefs, ref, name)
 }
 
+// display symbol slightly larger as zoom goes higher
+const getK = (zoom: number): number => 0.5 + 0.5 * Math.log2(Math.max(1, zoom))
+
 export function updateMapStyleRefs(
   layout: Readonly<Layout>,
   zoom: number
 ): void {
+  const k = getK(zoom)
+  const sz = layout.config.fontSize * layout.svgScale * getK(zoom)
+  Array.from(mapStyleRefs, ([, e]) => {
+    const p = e.style.setProperty.bind(e.style)
+    p(`--map-symbol-size`, `${sz / 72}`)
+    p(`--map-symbol-size-k`, `${k}`)
+  })
+}
+
+/*
+type SymbolSizeData = Readonly<{
+  readonly layout: Layout
+  readonly zoom: number
+  readonly s: number
+}>
+type SymbolSizeValues = number
+
+function getCurrentSymbolSizeValues(
+  { layout, zoom, s }: SymbolSizeData,
+  t: number
+): SymbolSizeValues {
   const sz =
     layout.config.fontSize *
     // display symbol slightly larger as zoom goes higher
     (0.5 + 0.5 * Math.log2(Math.max(1, zoom))) *
     layout.svgScale
+  const a = sz / 72
+  const b = a * s
+  return lerp(a, b, 1 / easeCubic(t))
+}
+
+function tickMapStyleRefs(t: number, cbdata?: SymbolSizeData): void {
+  if (!cbdata) return
+  const symbolSize = getCurrentSymbolSizeValues(cbdata, t)
   Array.from(mapStyleRefs, ([, e]) => {
     const p = e.style.setProperty.bind(e.style)
-    p(`--map-symbol-size`, `${sz / 72}`)
+    p(`--map-symbol-size`, `${symbolSize}`)
   })
 }
+*/

--- a/packages/lib/src/lib/rgb.ts
+++ b/packages/lib/src/lib/rgb.ts
@@ -10,11 +10,16 @@ export function rgbToString({ r, g, b }: Readonly<Rgb>): string {
   return `rgb(${d(r)}, ${d(g)}, ${d(b)})`
 }
 
+const rgbCache = new Map<string, string>()
+
 export const toRgbString = (c: string): string => {
+  const prev = rgbCache.get(c)
+  if (prev) return prev
   tmp.style.color = c
   document.body.appendChild(tmp)
   const s = getComputedStyle(tmp).color
   document.body.removeChild(tmp)
+  rgbCache.set(c, s)
   return s
 }
 

--- a/packages/lib/src/lib/style/style-react.ts
+++ b/packages/lib/src/lib/style/style-react.ts
@@ -11,6 +11,9 @@ export function useRendered(): boolean {
 export function useLayout(): Layout {
   return useStyleContext((ctx) => ctx.layout)
 }
+export function useLayoutSvg(): BoxBox {
+  return useStyleContext((ctx) => ctx.layout.svg)
+}
 export function useLayoutContainer(): BoxBox {
   return useStyleContext((ctx) => ctx.layout.container)
 }

--- a/packages/lib/src/lib/style/style-xstate.ts
+++ b/packages/lib/src/lib/style/style-xstate.ts
@@ -8,7 +8,11 @@ import { findRadius } from '../distance'
 import { scrollCbs } from '../event-scroll'
 import { styleCbs } from '../event-style'
 import { updateMapStyleRefs } from '../map/style'
-import { updateCoordRefs, updateDistanceRefs } from '../ui/Measure'
+import {
+  updateCoordRefs,
+  updateDistanceRefs,
+  updateMeasureRefs,
+} from '../ui/Measure'
 import { vecZero } from '../vec/prefixed'
 import { fromSvgToScroll } from '../viewer/layout/coord'
 import { emptyLayout, type Layout } from '../viewer/layout/layout'
@@ -66,6 +70,12 @@ const styleMachine = setup({
     updateCoord: ({ context: { geoPoint } }) => updateCoordRefs(geoPoint),
     updateDistance: ({ context: { distanceRadius } }) =>
       updateDistanceRefs(distanceRadius),
+    updateMeasure: ({ context: { layout, distanceRadius } }) =>
+      updateMeasureRefs(
+        layout.container.width,
+        layout.container.height,
+        distanceRadius.client
+      ),
   },
 }).createMachine({
   id: 'style1',
@@ -101,6 +111,7 @@ const styleMachine = setup({
         'updateGeoMatrix',
         'updateDistanceRadius',
         'updateDistance',
+        'updateMeasure',
         raise(({ event: { rendered } }) => ({ type: 'LAYOUT.DONE', rendered })),
         ({ context }) => updateLayoutStyleRefs(context.layout),
         ({ context }) => updateMapStyleRefs(context.layout, context.zoom),

--- a/packages/lib/src/lib/style/style-xstate.ts
+++ b/packages/lib/src/lib/style/style-xstate.ts
@@ -8,7 +8,7 @@ import { findRadius } from '../distance'
 import { scrollCbs } from '../event-scroll'
 import { styleCbs } from '../event-style'
 import { updateMapStyleRefs } from '../map/style'
-import { updateCoordRefs } from '../ui/Measure'
+import { updateCoordRefs, updateDistanceRefs } from '../ui/Measure'
 import { vecZero } from '../vec/prefixed'
 import { fromSvgToScroll } from '../viewer/layout/coord'
 import { emptyLayout, type Layout } from '../viewer/layout/layout'
@@ -64,6 +64,8 @@ const styleMachine = setup({
       },
     }),
     updateCoord: ({ context: { geoPoint } }) => updateCoordRefs(geoPoint),
+    updateDistance: ({ context: { distanceRadius } }) =>
+      updateDistanceRefs(distanceRadius),
   },
 }).createMachine({
   id: 'style1',
@@ -98,6 +100,7 @@ const styleMachine = setup({
         'updateSvgMatrix',
         'updateGeoMatrix',
         'updateDistanceRadius',
+        'updateDistance',
         raise(({ event: { rendered } }) => ({ type: 'LAYOUT.DONE', rendered })),
         ({ context }) => updateLayoutStyleRefs(context.layout),
         ({ context }) => updateMapStyleRefs(context.layout, context.zoom),

--- a/packages/lib/src/lib/style/style-xstate.ts
+++ b/packages/lib/src/lib/style/style-xstate.ts
@@ -171,6 +171,9 @@ const styleMachine = setup({
             ({ context: { zoom } }) => updateZoomStyleRefs(null, zoom),
             ({ context }) =>
               updateAppearingStyleRefs(context.shown, context.appearing),
+            // after initial rendering
+            'updateDistance',
+            'updateMeasure',
           ],
           target: 'Idle',
         },

--- a/packages/lib/src/lib/style/style-xstate.ts
+++ b/packages/lib/src/lib/style/style-xstate.ts
@@ -16,7 +16,10 @@ import {
 import { vecZero } from '../vec/prefixed'
 import { fromSvgToScroll } from '../viewer/layout/coord'
 import { emptyLayout, type Layout } from '../viewer/layout/layout'
-import { updateZoomStyleRefs } from '../viewer/layout/style'
+import {
+  updateSvgScaleStyleRefs,
+  updateZoomStyleRefs,
+} from '../viewer/layout/style'
 import { updateLayoutStyleRefs } from '../viewer/layout/style'
 import { getCurrentScroll } from '../viewer/scroll/scroll'
 import { type ViewerMode } from '../viewer/viewer-types'
@@ -114,6 +117,7 @@ const styleMachine = setup({
         'updateMeasure',
         raise(({ event: { rendered } }) => ({ type: 'LAYOUT.DONE', rendered })),
         ({ context }) => updateLayoutStyleRefs(context.layout),
+        ({ context }) => updateSvgScaleStyleRefs(context.layout),
         ({ context }) => updateMapStyleRefs(context.layout, context.zoom),
       ],
     },

--- a/packages/lib/src/lib/style/style-xstate.ts
+++ b/packages/lib/src/lib/style/style-xstate.ts
@@ -8,6 +8,7 @@ import { findRadius } from '../distance'
 import { scrollCbs } from '../event-scroll'
 import { styleCbs } from '../event-style'
 import { updateMapStyleRefs } from '../map/style'
+import { updateCoordRefs } from '../ui/Measure'
 import { vecZero } from '../vec/prefixed'
 import { fromSvgToScroll } from '../viewer/layout/coord'
 import { emptyLayout, type Layout } from '../viewer/layout/layout'
@@ -62,6 +63,7 @@ const styleMachine = setup({
         }
       },
     }),
+    updateCoord: ({ context: { geoPoint } }) => updateCoordRefs(geoPoint),
   },
 }).createMachine({
   id: 'style1',
@@ -111,10 +113,13 @@ const styleMachine = setup({
       ],
     },
     'STYLE.SCROLL': {
-      actions: {
-        type: 'updateScroll',
-        params: ({ event }) => event.currentScroll,
-      },
+      actions: [
+        {
+          type: 'updateScroll',
+          params: ({ event }) => event.currentScroll,
+        },
+        'updateCoord',
+      ],
     },
     'STYLE.MODE': {
       actions: assign({

--- a/packages/lib/src/lib/style/tag.ts
+++ b/packages/lib/src/lib/style/tag.ts
@@ -1,7 +1,7 @@
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/no-return-void */
 export function tag(
-  e: Readonly<HTMLElement>,
+  e: Readonly<HTMLElement | SVGElement>,
   name: string,
   adding: boolean
 ): void {
@@ -10,7 +10,7 @@ export function tag(
 }
 
 export function tag2(
-  e: Readonly<HTMLElement>,
+  e: Readonly<HTMLElement | SVGElement>,
   p: string,
   q: string,
   adding: boolean

--- a/packages/lib/src/lib/ui/DetailBalloon.tsx
+++ b/packages/lib/src/lib/ui/DetailBalloon.tsx
@@ -5,7 +5,7 @@ import { type ReactNode } from 'react'
 import { RenderMapAssetsDefault } from '../carto/assets'
 import { useShadowRoot } from '../dom'
 import { Balloon } from './Balloon'
-import { balloonStyleString } from './balloon-common'
+import { detailStyleString } from './balloon-common'
 import { Detail } from './Detail'
 
 export function DetailBalloon(): ReactNode {
@@ -19,7 +19,7 @@ export function DetailBalloonRoot(): ReactNode {
     <div className="ui-content detail-balloon">
       <Balloon />
       <Detail />
-      <style>{balloonStyleString}</style>
+      <style>{detailStyleString}</style>
       <Assets />
     </div>
   )

--- a/packages/lib/src/lib/ui/Floor.tsx
+++ b/packages/lib/src/lib/ui/Floor.tsx
@@ -1,20 +1,25 @@
+/* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { type ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
 
 import { useConfig } from '../../config'
 import { background_white_opaque, floor_switch_duration } from '../css'
+import { useStyleRef } from '../style/ref'
 import { useFloors } from '../viewer/floors/floors-react'
+import { scrollLockRefs } from '../viewer/scroll/scroll'
 
 export function Floors(): ReactNode {
+  const ref = useRef(null)
   const { fidx, fidxToOnClick } = useFloors()
   const cfg = useConfig()
-  const floorsConfig = cfg.floorsConfig
-  return floorsConfig === undefined || floorsConfig.floors.length < 2 ? (
+  useStyleRef(scrollLockRefs, ref, 'floors')
+  return cfg.floorsConfig === undefined ||
+    cfg.floorsConfig.floors.length < 2 ? (
     <></>
   ) : (
-    <div className="floors">
+    <div ref={ref} className="floors">
       <ul className="floor-list">
-        {floorsConfig.floors.map(({ name }, idx) => (
+        {cfg.floorsConfig.floors.map(({ name }, idx) => (
           <li
             key={idx}
             className={`floor-item ${s(idx === fidx)}`}
@@ -36,6 +41,12 @@ const floorsStyle = `
   scrollbar-width: none;
   pointer-events: initial;
   touch-action: pan-x;
+  &.locked {
+    & > .floor-list {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+  }
 }
 .floor-list {
   margin: 0.25em;
@@ -44,6 +55,7 @@ const floorsStyle = `
   display: flex;
   flex-direction: column-reverse;
   ${background_white_opaque}
+  transition: opacity 100ms;
 }
 .floor-item {
   text-align: center;

--- a/packages/lib/src/lib/ui/Footer.tsx
+++ b/packages/lib/src/lib/ui/Footer.tsx
@@ -66,11 +66,10 @@ const style = `
   }
 }
 .footer {
-  opacity: var(--footer-scale);
   transform-origin: 50% 100%;
-  transform: translate(calc(50vw - 50%), 0%) scale(var(--footer-scale));
   &.not-animating {
-    --footer-scale: var(--b);
+    opacity: var(--b);
+    transform: translate(calc(50vw - 50%), 0%) scale(var(--b));
     &.closed {
       --b: 0;
     }
@@ -98,10 +97,12 @@ const style = `
 }
 @keyframes xxx-footer {
   from {
-    --footer-scale: var(--a);
+    opacity: var(--a);
+    transform: translate(calc(50vw - 50%), 0%) scale(var(--a));
   }
   to {
-    --footer-scale: var(--b);
+    opacity: var(--b);
+    transform: translate(calc(50vw - 50%), 0%) scale(var(--b));
   }
 }
 `

--- a/packages/lib/src/lib/ui/Guides.tsx
+++ b/packages/lib/src/lib/ui/Guides.tsx
@@ -15,6 +15,7 @@ import {
   ZOOM_DURATION_HEADER,
 } from '../css'
 import { useShadowRoot } from '../dom'
+import { useZoomCondStyleRef } from '../viewer/layout/style'
 import { Measure, MeasureCoordinate, MeasureDistance } from './Measure'
 import { useHeaderStyleRef } from './style'
 
@@ -31,6 +32,7 @@ function GuidesRoot(): ReactNode {
   const ref = useRef<HTMLDivElement>(null)
 
   useHeaderStyleRef(ref, 'guides')
+  useZoomCondStyleRef(ref, 'guides')
 
   const cfg = useConfig()
 
@@ -59,28 +61,34 @@ const style = `
 .guides {
   &.not-animating {
     &.closed {
-      --ob: 0;
+      --b: 0;
     }
     &.opened {
-      --ob: 1;
+      --b: 1;
     }
-    opacity: var(--ob);
+    opacity: var(--b);
     will-change: opacity;
   }
   &.animating {
     &.closed {
-      --oa: 1;
-      --ob: 0;
+      --a: 1;
+      --b: 0;
       --timing: ${timing_closing};
     }
     &.opened {
-      --oa: 0;
-      --ob: 1;
+      --a: 0;
+      --b: 1;
       --timing: ${timing_opening};
     }
     --duration: ${ZOOM_DURATION_HEADER}ms;
     animation: xxx-measure var(--duration) var(--timing);
     will-change: opacity;
+  }
+  &.zooming {
+    display: none;
+    --b: 0;
+  }
+  &.not-zooming {
   }
 }
 text {
@@ -88,10 +96,10 @@ text {
 }
 @keyframes xxx-measure {
   from {
-    opacity: var(--oa);
+    opacity: var(--a);
   }
   to {
-    opacity: var(--ob);
+    opacity: var(--b);
   }
 }
 `

--- a/packages/lib/src/lib/ui/Guides.tsx
+++ b/packages/lib/src/lib/ui/Guides.tsx
@@ -15,7 +15,6 @@ import {
   ZOOM_DURATION_HEADER,
 } from '../css'
 import { useShadowRoot } from '../dom'
-import { useLayoutStyleRef } from '../viewer/layout/style'
 import { Measure, MeasureCoordinate, MeasureDistance } from './Measure'
 import { useHeaderStyleRef } from './style'
 
@@ -32,7 +31,6 @@ function GuidesRoot(): ReactNode {
   const ref = useRef<HTMLDivElement>(null)
 
   useHeaderStyleRef(ref, 'guides')
-  useLayoutStyleRef(ref, 'guides')
 
   const cfg = useConfig()
 
@@ -55,6 +53,7 @@ const style = `
   ${position_absolute_left_0_top_0}
   ${width_100vw_height_100svh}
   ${pointer_events_none}
+  transform: translate(0%, 0%);
   z-index: ${Z_INDEX_GUIDES};
 }
 .guides {

--- a/packages/lib/src/lib/ui/Guides.tsx
+++ b/packages/lib/src/lib/ui/Guides.tsx
@@ -15,6 +15,7 @@ import {
   ZOOM_DURATION_HEADER,
 } from '../css'
 import { useShadowRoot } from '../dom'
+import { useLayoutStyleRef } from '../viewer/layout/style'
 import { Measure, MeasureCoordinate, MeasureDistance } from './Measure'
 import { useHeaderStyleRef } from './style'
 
@@ -31,6 +32,7 @@ function GuidesRoot(): ReactNode {
   const ref = useRef<HTMLDivElement>(null)
 
   useHeaderStyleRef(ref, 'guides')
+  useLayoutStyleRef(ref, 'guides')
 
   const cfg = useConfig()
 

--- a/packages/lib/src/lib/ui/Header.tsx
+++ b/packages/lib/src/lib/ui/Header.tsx
@@ -80,11 +80,10 @@ const style = `
   }
 }
 .header {
-  opacity: var(--header-scale);
   transform-origin: 50% 0%;
-  transform: translate(calc(50vw - 50%), 0%) scale(var(--header-scale)) translate3d(0px, 0px, 0px);
   &.not-animating {
-    --header-scale: var(--b);
+    opacity: var(--b);
+    transform: translate(calc(50vw - 50%), 0%) scale(var(--b)) translate3d(0px, 0px, 0px);
     &.closed {
       --b: 0;
     }
@@ -112,10 +111,12 @@ const style = `
 }
 @keyframes xxx-header {
   from {
-    --header-scale: var(--a);
+    opacity: var(--a);
+    transform: translate(calc(50vw - 50%), 0%) scale(var(--a));
   }
   to {
-    --header-scale: var(--b);
+    opacity: var(--b);
+    transform: translate(calc(50vw - 50%), 0%) scale(var(--b));
   }
 }
 `

--- a/packages/lib/src/lib/ui/Left.tsx
+++ b/packages/lib/src/lib/ui/Left.tsx
@@ -44,12 +44,10 @@ const style = `
   align-items: end;
 }
 .left {
-  opacity: var(--left-scale);
   transform-origin: 0% 50%;
-  transform: translate(0%, calc(50vh - 50%)) scale(var(--left-scale));
-  --b: 1;
   &.not-animating {
-    --left-scale: var(--b);
+    opacity: var(--b);
+    transform: translate(0%, calc(50vh - 50%)) scale(var(--b));
     &.closed {
       --b: 0;
     }
@@ -69,16 +67,18 @@ const style = `
       --timing: ${timing_opening};
     }
     --duration: ${ZOOM_DURATION_HEADER}ms;
-    animation: xxx-left var(--duration) var(--timing);
     will-change: opacity, transform;
+    animation: xxx-left var(--duration) var(--timing) forwards;
   }
 }
 @keyframes xxx-left {
   from {
-    --left-scale: var(--a);
+    opacity: var(--a);
+    transform: translate(0%, calc(50vh - 50%)) scale(var(--a));
   }
   to {
-    --left-scale: var(--b);
+    opacity: var(--b);
+    transform: translate(0%, calc(50vh - 50%)) scale(var(--b));
   }
 }
 `

--- a/packages/lib/src/lib/ui/Left.tsx
+++ b/packages/lib/src/lib/ui/Left.tsx
@@ -45,9 +45,9 @@ const style = `
 }
 .left {
   transform-origin: 0% 50%;
+  transform: translate(0%, calc(50vh - 50%)) scale(var(--b));
   &.not-animating {
     opacity: var(--b);
-    transform: translate(0%, calc(50vh - 50%)) scale(var(--b));
     &.closed {
       --b: 0;
     }

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -12,7 +12,7 @@ import {
 } from '../css'
 import type { DistanceRadius } from '../distance-types'
 import { useStyleRef, type StyleRefMap } from '../style/ref'
-import { trunc7 } from '../utils'
+import { trunc2, trunc7 } from '../utils'
 import type { VecVec } from '../vec/prefixed'
 
 // XXX
@@ -125,7 +125,7 @@ export function updateMeasureRefs(
   INDEXES.forEach((i) => {
     const e = measureRefs.get(`ring${i}`)
     if (!e) return
-    const r = client * (i + 1)
+    const r = trunc2(client * (i + 1))
     const d = ringPath({ width, height, r })
     e.setAttribute('d', d)
   })
@@ -188,6 +188,7 @@ function RingPath({ idx }: Readonly<{ idx: number }>): ReactNode {
 // XXX
 // XXX
 // XXX
+const pathCache = new Map<string, string>()
 function ringPath({
   width,
   height,
@@ -197,10 +198,15 @@ function ringPath({
   height: number
   r: number
 }>): string {
-  return `M${width / 2},${height / 2} m-${r},0 a${r},${r} 0,1,0 ${r * 2},0 a${r},${r} 0,1,0 -${r * 2},0`.replaceAll(
-    /([.]\d)\d*/g,
-    '$1'
-  )
+  const key = `${width}:${height}:${r}`
+  const prev = pathCache.get(key)
+  const d =
+    `M${width / 2},${height / 2} m-${r},0 a${r},${r} 0,1,0 ${r * 2},0 a${r},${r} 0,1,0 -${r * 2},0`.replaceAll(
+      /([.]\d)\d*/g,
+      '$1'
+    )
+  if (!prev) pathCache.set(key, d)
+  return d
 }
 // XXX
 // XXX

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -10,10 +10,21 @@ import {
   position_absolute_left_0_top_0,
   position_absolute_right_0_bottom_0,
 } from '../css'
+import type { DistanceRadius } from '../distance-types'
 import { useStyleRef, type StyleRefMap } from '../style/ref'
 import { useDistanceRadius, useLayoutContainer } from '../style/style-react'
 import { trunc7 } from '../utils'
 import type { VecVec } from '../vec/prefixed'
+
+// XXX
+// XXX
+// XXX
+const INDEXES = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+]
+// XXX
+// XXX
+// XXX
 
 export function Measure(): ReactNode {
   return (
@@ -35,10 +46,13 @@ export function Measure(): ReactNode {
 }
 
 export function MeasureDistance(): ReactNode {
+  const ref = useRef(null)
   const { svg } = useDistanceRadius()
 
+  useStyleRef(distanceRefs, ref, 'distance')
+
   return (
-    <div id="distance">
+    <div ref={ref} id="distance">
       <p id={`distance-origin`} className="distance">
         0m
       </p>
@@ -155,6 +169,11 @@ export function MeasurePaths(): ReactNode {
   )
 }
 
+// XXX
+// XXX
+// XXX
+// XXX
+// XXX
 function ringPath({
   width,
   height,
@@ -169,40 +188,13 @@ function ringPath({
     '$1'
   )
 }
+// XXX
+// XXX
+// XXX
+// XXX
+// XXX
 
 export function CoordinateStyle(): ReactNode {
-  const { width, height } = useLayoutContainer()
-
-  const coordinateStyle = `
-#distance,
-#coordinate {
-  ${position_absolute_left_0_top_0}
-  width: ${width}px;
-  height: ${height}px;
-  transform: translate3d(0, 0, 0);
-}
-`
-
-  const longitudeStyle = `
-#longitude {
-  ${position_absolute_right_0_bottom_0}
-  margin: 0.1em;
-  padding: 0;
-  font-weight: lighter;
-  transform-origin: right bottom;
-  transform: translate(${-width / 2}px, ${-height / 2}px) scale(0.5);
-}
-`
-  const latitudeStyle = `
-#latitude {
-  ${position_absolute_left_0_bottom_0}
-  margin: 0.1em;
-  padding: 0;
-  font-weight: lighter;
-  transform-origin: left bottom;
-  transform: translate(${width / 2}px, ${-height / 2}px) scale(0.5);
-}
-`
   return (
     <>
       {coordinateStyle}
@@ -212,42 +204,47 @@ export function CoordinateStyle(): ReactNode {
   )
 }
 
-export function DistanceStyle(): ReactNode {
-  const { width, height } = useLayoutContainer()
-  const { client } = useDistanceRadius()
-
-  const distanceStyle = `
-.distance {
+const coordinateStyle = `
+#distance,
+#coordinate {
   ${position_absolute_left_0_top_0}
+  width: var(--layout-container-width);
+  height: var(--layout-container-height);
+  transform: translate3d(0, 0, 0);
+}
+`
+
+const longitudeStyle = `
+#longitude {
+  ${position_absolute_right_0_bottom_0}
   margin: 0.1em;
   padding: 0;
   font-weight: lighter;
-  transform-origin: left top;
+  transform-origin: right bottom;
+  transform: translate(calc(var(--layout-container-width) / -2), calc(var(--layout-container-height) / 2)) scale(0.5);
 }
 `
-  const distanceOriginStyle = `
-#distance-origin {
-  transform: translate(${width / 2}px, ${height / 2}px) scale(0.5);
+const latitudeStyle = `
+#latitude {
+  ${position_absolute_left_0_bottom_0}
+  margin: 0.1em;
+  padding: 0;
+  font-weight: lighter;
+  transform-origin: left bottom;
+  transform: translate(calc(var(--layout-container-width) / 2)), calc(var(--layout-container-height) / -2)) scale(0.5);
 }
 `
-  const distanceXStyle = INDEXES.map((i) => {
-    const r = client * (i + 1)
-    return `
-#distance-x-${i + 1} {
-  transform: translate(${width / 2 + r}px, ${height / 2}px) scale(0.5);
-}
-`
-  })
 
-  const distanceYStyle = INDEXES.map((i) => {
-    const r = client * (i + 1)
-    return `
-#distance-y-${i + 1} {
-  transform: translate(${width / 2}px, ${height / 2 + r}px) scale(0.5);
-}
-`
-  })
+const distanceRefs: StyleRefMap<HTMLDivElement> = new Map()
 
+export function updateDistanceRefs({ client }: Readonly<DistanceRadius>): void {
+  Array.from(distanceRefs, ([, e]) => {
+    const p = e.style.setProperty.bind(e.style)
+    p('--distance-radius-client', `${client}px`)
+  })
+}
+
+export function DistanceStyle(): ReactNode {
   return (
     <>
       {distanceOriginStyle}
@@ -258,12 +255,42 @@ export function DistanceStyle(): ReactNode {
   )
 }
 
-// XXX
-// XXX
-// XXX
-const INDEXES = [
-  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-]
-// XXX
-// XXX
-// XXX
+const distanceStyle = `
+.distance {
+  ${position_absolute_left_0_top_0}
+  margin: 0.1em;
+  padding: 0;
+  font-weight: lighter;
+  transform-origin: left top;
+}
+`
+const distanceOriginStyle = `
+#distance-origin {
+  transform: translate(calc(var(--layout-container-width) / 2), calc(var(--layout-container-height) / 2)) scale(0.5);
+}
+`
+const distanceXStyle = INDEXES.map((i) => {
+  const width = `var(--layout-container-width)`
+  const height = `var(--layout-container-height)`
+  const r = `var(--distance-radius-client) * (${i} + 1)`
+  const x = `calc(${width} / 2 + ${r})`
+  const y = `calc(${height} / 2)`
+  return `
+#distance-x-${i + 1} {
+  transform: translate(${x}, ${y}) scale(0.5);
+}
+`
+})
+
+const distanceYStyle = INDEXES.map((i) => {
+  const width = `var(--layout-container-width)`
+  const height = `var(--layout-container-height)`
+  const r = `var(--distance-radius-client) * (${i} + 1)`
+  const x = `calc(${width} / 2)`
+  const y = `calc(${height} / 2 + ${r})`
+  return `
+#distance-y-${i + 1} {
+  transform: translate(${x}, ${y}) scale(0.5);
+}
+`
+})

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -1,17 +1,19 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable functional/no-conditional-statements */
+/* eslint-disable functional/no-return-void */
+/* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { Fragment, useMemo, type ReactNode } from 'react'
+import { Fragment, useMemo, useRef, type ReactNode } from 'react'
 
 import {
   position_absolute_left_0_bottom_0,
   position_absolute_left_0_top_0,
   position_absolute_right_0_bottom_0,
 } from '../css'
-import {
-  useDistanceRadius,
-  useGeoPoint,
-  useLayoutContainer,
-} from '../style/style-react'
+import { useStyleRef, type StyleRefMap } from '../style/ref'
+import { useDistanceRadius, useLayoutContainer } from '../style/style-react'
 import { trunc7 } from '../utils'
+import type { VecVec } from '../vec/prefixed'
 
 export function Measure(): ReactNode {
   return (
@@ -57,19 +59,31 @@ export function MeasureDistance(): ReactNode {
   )
 }
 
-export function MeasureCoordinate(): ReactNode {
-  const pgeo = useGeoPoint()
+const coordRefs: StyleRefMap<HTMLDivElement> = new Map()
 
+export function updateCoordRefs(pgeo: VecVec): void {
   const ew = pgeo.x > 0 ? 'E' : 'W'
   const ns = pgeo.y > 0 ? 'N' : 'S'
   const lon = `${ew} ${trunc7(Math.abs(pgeo.x))}`
   const lat = `${ns} ${trunc7(Math.abs(pgeo.y))}`
+  Array.from(coordRefs, ([name, e]) => {
+    if (name === 'lon') e.textContent = lon
+    if (name === 'lat') e.textContent = lat
+  })
+}
+
+export function MeasureCoordinate(): ReactNode {
+  const lonRef = useRef(null)
+  const latRef = useRef(null)
+
+  useStyleRef(coordRefs, lonRef, 'lon')
+  useStyleRef(coordRefs, latRef, 'lat')
 
   return (
     <div id="coordinate">
       {/* placeholder - updated by style coord */}
-      <p id="longitude">{lon}</p>
-      <p id="latitude">{lat}</p>
+      <p ref={lonRef} id="longitude"></p>
+      <p ref={latRef} id="latitude"></p>
       <style>
         <CoordinateStyle />
       </style>

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -252,7 +252,9 @@ const coordinateStyle = `
   ${position_absolute_left_0_top_0}
   width: ${width};
   height: ${height};
+  /*
   transform: translate3d(0, 0, 0);
+  */
 }
 `
 const longitudeStyle = `

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable functional/no-return-void */
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { Fragment, useRef, type ReactNode } from 'react'
+import { Fragment, useRef, type CSSProperties, type ReactNode } from 'react'
 
 import {
   position_absolute_left_0_bottom_0,
@@ -56,8 +56,26 @@ export function MeasureDistance(): ReactNode {
       </p>
       {INDEXES.map((i) => (
         <Fragment key={i}>
-          <p id={`distance-x-${i + 1}`} className="distance distance-x"></p>
-          <p id={`distance-y-${i + 1}`} className="distance distance-y"></p>
+          <p
+            id={`distance-x-${i + 1}`}
+            className="distance distance-x"
+            data-idx={i + 1}
+            style={
+              {
+                '--distance-idx': `${i + 1}`,
+              } as CSSProperties
+            }
+          ></p>
+          <p
+            id={`distance-y-${i + 1}`}
+            className="distance distance-y"
+            data-idx={i + 1}
+            style={
+              {
+                '--distance-idx': `${i + 1}`,
+              } as CSSProperties
+            }
+          ></p>
         </Fragment>
       ))}
       <style>
@@ -267,11 +285,9 @@ export function updateDistanceRefs({
   Array.from(distanceRefs, ([, e]) => {
     // 1. update <p></p>
     Array.from(e.children, (child) => {
-      // id must be like: 'distance-x-1'
-      const ss = child.id.split(/-/g)
-      if (ss.length !== 3 || ss[0] !== 'distance' || !ss[1].match(/^[xy]$/))
-        return
-      const idx = Number(ss[2])
+      const ss = child.getAttribute('data-idx')
+      if (!ss) return
+      const idx = Number(ss)
       if (typeof idx !== 'number') return
       child.textContent = `${svg * idx}m`
     })
@@ -306,24 +322,24 @@ const distanceOriginStyle = `
   transform: translate(calc(${width} / 2), calc(${height} / 2)) scale(0.5);
 }
 `
-const distanceXStyle = INDEXES.map((i) => {
-  const r = `${client} * (${i} + 1)`
+const distanceXStyle = (() => {
+  const r = `${client} * var(--distance-idx)`
   const x = `${width} / 2 + ${r}`
   const y = `${height} / 2`
   return `
-#distance-x-${i + 1} {
+.distance-x {
   transform: translate(calc(${x}), calc(${y})) scale(0.5);
 }
 `
-})
+})()
 
-const distanceYStyle = INDEXES.map((i) => {
-  const r = `${client} * (${i} + 1)`
+const distanceYStyle = (() => {
+  const r = `${client} * var(--distance-idx)`
   const x = `${width} / 2`
   const y = `${height} / 2 + ${r}`
   return `
-#distance-y-${i + 1} {
+.distance-y {
   transform: translate(calc(${x}), calc(${y})) scale(0.5);
 }
 `
-})
+})()

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -12,7 +12,6 @@ import {
 } from '../css'
 import type { DistanceRadius } from '../distance-types'
 import { useStyleRef, type StyleRefMap } from '../style/ref'
-import { useDistanceRadius } from '../style/style-react'
 import { trunc7 } from '../utils'
 import type { VecVec } from '../vec/prefixed'
 
@@ -47,7 +46,6 @@ export function Measure(): ReactNode {
 
 export function MeasureDistance(): ReactNode {
   const ref = useRef(null)
-  const { svg } = useDistanceRadius()
 
   useStyleRef(distanceRefs, ref, 'distance')
 
@@ -58,12 +56,8 @@ export function MeasureDistance(): ReactNode {
       </p>
       {INDEXES.map((i) => (
         <Fragment key={i}>
-          <p id={`distance-x-${i + 1}`} className="distance distance-x">
-            {svg * (i + 1)}m
-          </p>
-          <p id={`distance-y-${i + 1}`} className="distance distance-y">
-            {svg * (i + 1)}m
-          </p>
+          <p id={`distance-x-${i + 1}`} className="distance distance-x"></p>
+          <p id={`distance-y-${i + 1}`} className="distance distance-y"></p>
         </Fragment>
       ))}
       <style>
@@ -140,31 +134,11 @@ export function updateMeasureRefs(
 export function MeasurePaths(): ReactNode {
   const horizontalRef = useRef(null)
   const vertcalRef = useRef(null)
-  /*
-  const { width, height } = useLayoutContainer()
-  const { client } = useDistanceRadius()
-  */
 
   useStyleRef(measureRefs, horizontalRef, `horizontal`)
   useStyleRef(measureRefs, vertcalRef, `vertical`)
 
   // XXX use cache
-
-  /*
-  const horizontal = useMemo(
-    () => `M0,${height / 2} h${width}`,
-    [height, width]
-  )
-  const vertical = useMemo(() => `M${width / 2},0 v${height}`, [height, width])
-  const rings = useMemo(
-    () =>
-      INDEXES.map((i) => {
-        const r = client * (i + 1)
-        return ringPath({ width, height, r })
-      }),
-    [client, height, width]
-  )
-  */
 
   // XXX use
   return (
@@ -186,7 +160,9 @@ export function MeasurePaths(): ReactNode {
         fill="none"
       />
       {INDEXES.map((_, idx) => (
-        <RingPath idx={idx} />
+        <Fragment key={idx}>
+          <RingPath idx={idx} />
+        </Fragment>
       ))}
     </>
   )
@@ -242,16 +218,19 @@ export function CoordinateStyle(): ReactNode {
   )
 }
 
+const width = `var(--layout-container-width)`
+const height = `var(--layout-container-height)`
+const client = `var(--distance-radius-client)`
+
 const coordinateStyle = `
 #distance,
 #coordinate {
   ${position_absolute_left_0_top_0}
-  width: var(--layout-container-width);
-  height: var(--layout-container-height);
+  width: ${width};
+  height: ${height};
   transform: translate3d(0, 0, 0);
 }
 `
-
 const longitudeStyle = `
 #longitude {
   ${position_absolute_right_0_bottom_0}
@@ -259,7 +238,7 @@ const longitudeStyle = `
   padding: 0;
   font-weight: lighter;
   transform-origin: right bottom;
-  transform: translate(calc(var(--layout-container-width) / -2), calc(var(--layout-container-height) / 2)) scale(0.5);
+  transform: translate(calc(${width} / -2), calc(${height} / -2)) scale(0.5);
 }
 `
 const latitudeStyle = `
@@ -269,14 +248,28 @@ const latitudeStyle = `
   padding: 0;
   font-weight: lighter;
   transform-origin: left bottom;
-  transform: translate(calc(var(--layout-container-width) / 2)), calc(var(--layout-container-height) / -2)) scale(0.5);
+  transform: translate(calc(${width} / 2), calc(${height} / -2)) scale(0.5);
 }
 `
 
 const distanceRefs: StyleRefMap<HTMLDivElement> = new Map()
 
-export function updateDistanceRefs({ client }: Readonly<DistanceRadius>): void {
+export function updateDistanceRefs({
+  svg,
+  client,
+}: Readonly<DistanceRadius>): void {
   Array.from(distanceRefs, ([, e]) => {
+    // 1. update <p></p>
+    Array.from(e.children, (child) => {
+      // id must be like: 'distance-x-1'
+      const ss = child.id.split(/-/g)
+      if (ss.length !== 3 || ss[0] !== 'distance' || !ss[1].match(/^[xy]$/))
+        return
+      const idx = Number(ss[2])
+      if (typeof idx !== 'number') return
+      child.textContent = `${svg * idx}m`
+    })
+    // 2. update style property
     const p = e.style.setProperty.bind(e.style)
     p('--distance-radius-client', `${client}px`)
   })
@@ -304,31 +297,27 @@ const distanceStyle = `
 `
 const distanceOriginStyle = `
 #distance-origin {
-  transform: translate(calc(var(--layout-container-width) / 2), calc(var(--layout-container-height) / 2)) scale(0.5);
+  transform: translate(calc(${width} / 2), calc(${height} / 2)) scale(0.5);
 }
 `
 const distanceXStyle = INDEXES.map((i) => {
-  const width = `var(--layout-container-width)`
-  const height = `var(--layout-container-height)`
-  const r = `var(--distance-radius-client) * (${i} + 1)`
-  const x = `calc(${width} / 2 + ${r})`
-  const y = `calc(${height} / 2)`
+  const r = `${client} * (${i} + 1)`
+  const x = `${width} / 2 + ${r}`
+  const y = `${height} / 2`
   return `
 #distance-x-${i + 1} {
-  transform: translate(${x}, ${y}) scale(0.5);
+  transform: translate(calc(${x}), calc(${y})) scale(0.5);
 }
 `
 })
 
 const distanceYStyle = INDEXES.map((i) => {
-  const width = `var(--layout-container-width)`
-  const height = `var(--layout-container-height)`
-  const r = `var(--distance-radius-client) * (${i} + 1)`
-  const x = `calc(${width} / 2)`
-  const y = `calc(${height} / 2 + ${r})`
+  const r = `${client} * (${i} + 1)`
+  const x = `${width} / 2`
+  const y = `${height} / 2 + ${r}`
   return `
 #distance-y-${i + 1} {
-  transform: translate(${x}, ${y}) scale(0.5);
+  transform: translate(calc(${x}), calc(${y})) scale(0.5);
 }
 `
 })

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable functional/no-return-void */
 /* eslint-disable functional/no-expression-statements */
 /* eslint-disable functional/functional-parameters */
-import { Fragment, useMemo, useRef, type ReactNode } from 'react'
+import { Fragment, useRef, type ReactNode } from 'react'
 
 import {
   position_absolute_left_0_bottom_0,
@@ -12,7 +12,7 @@ import {
 } from '../css'
 import type { DistanceRadius } from '../distance-types'
 import { useStyleRef, type StyleRefMap } from '../style/ref'
-import { useDistanceRadius, useLayoutContainer } from '../style/style-react'
+import { useDistanceRadius } from '../style/style-react'
 import { trunc7 } from '../utils'
 import type { VecVec } from '../vec/prefixed'
 
@@ -115,12 +115,42 @@ export function MeasurePathUse(): ReactNode {
   )
 }
 
+const measureRefs: StyleRefMap<SVGPathElement> = new Map()
+
+export function updateMeasureRefs(
+  width: number,
+  height: number,
+  client: number
+): void {
+  const horizontal = `M0,${height / 2} h${width}`
+  const vertical = `M${width / 2},0 v${height}`
+  const h = measureRefs.get('horizontal')
+  if (h) h.setAttribute('d', horizontal)
+  const v = measureRefs.get('vertical')
+  if (v) v.setAttribute('d', vertical)
+  INDEXES.forEach((i) => {
+    const e = measureRefs.get(`ring${i}`)
+    if (!e) return
+    const r = client * (i + 1)
+    const d = ringPath({ width, height, r })
+    e.setAttribute('d', d)
+  })
+}
+
 export function MeasurePaths(): ReactNode {
+  const horizontalRef = useRef(null)
+  const vertcalRef = useRef(null)
+  /*
   const { width, height } = useLayoutContainer()
   const { client } = useDistanceRadius()
+  */
+
+  useStyleRef(measureRefs, horizontalRef, `horizontal`)
+  useStyleRef(measureRefs, vertcalRef, `vertical`)
 
   // XXX use cache
 
+  /*
   const horizontal = useMemo(
     () => `M0,${height / 2} h${width}`,
     [height, width]
@@ -134,38 +164,46 @@ export function MeasurePaths(): ReactNode {
       }),
     [client, height, width]
   )
+  */
 
   // XXX use
   return (
     <>
       <path
+        ref={horizontalRef}
         id="measure-horizontal"
         className="measure-line"
         stroke="black"
         strokeWidth="0.1px"
         fill="none"
-        d={horizontal}
       />
       <path
+        ref={vertcalRef}
         id="measure-vertical"
         className="measure-line"
         stroke="black"
         strokeWidth="0.1px"
         fill="none"
-        d={vertical}
       />
-      {rings.map((d, idx) => (
-        <path
-          key={idx}
-          id={`measure-ring-${idx + 1}`}
-          className="measure-line"
-          stroke="black"
-          strokeWidth="0.1px"
-          fill="none"
-          d={d}
-        />
+      {INDEXES.map((_, idx) => (
+        <RingPath idx={idx} />
       ))}
     </>
+  )
+}
+
+function RingPath({ idx }: Readonly<{ idx: number }>): ReactNode {
+  const ref = useRef(null)
+  useStyleRef(measureRefs, ref, `ring${idx}`)
+  return (
+    <path
+      ref={ref}
+      id={`measure-ring-${idx + 1}`}
+      className="measure-line"
+      stroke="black"
+      strokeWidth="0.1px"
+      fill="none"
+    />
   )
 }
 

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -292,7 +292,7 @@ const distanceStyle = `
   margin: 0.1em;
   padding: 0;
   font-weight: lighter;
-  transform-origin: left top;
+  transform-origin: 0% 0%;
 }
 `
 const distanceOriginStyle = `

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -218,8 +218,8 @@ export function CoordinateStyle(): ReactNode {
   )
 }
 
-const width = `var(--layout-container-width)`
-const height = `var(--layout-container-height)`
+const width = `100vw`
+const height = `100svh`
 const client = `var(--distance-radius-client)`
 
 const coordinateStyle = `

--- a/packages/lib/src/lib/ui/Measure.tsx
+++ b/packages/lib/src/lib/ui/Measure.tsx
@@ -179,6 +179,7 @@ export function CoordinateStyle(): ReactNode {
   ${position_absolute_left_0_top_0}
   width: ${width}px;
   height: ${height}px;
+  transform: translate3d(0, 0, 0);
 }
 `
 

--- a/packages/lib/src/lib/ui/Right.tsx
+++ b/packages/lib/src/lib/ui/Right.tsx
@@ -13,6 +13,8 @@ import {
   timing_opening,
 } from '../css'
 import { useShadowRoot } from '../dom'
+import { useStyleRef } from '../style/ref'
+import { scrollLockRefs } from '../viewer/scroll/scroll'
 import { Fullscreen } from './buttons/Fullscreen'
 import { Home } from './buttons/Home'
 import { Position } from './buttons/Position'
@@ -95,8 +97,10 @@ const style = `
 `
 
 function Buttons(): ReactNode {
+  const ref = useRef(null)
+  useStyleRef(scrollLockRefs, ref, 'buttons')
   return (
-    <div className="button">
+    <div ref={ref} className="buttons">
       <Position />
       <Home />
       <Fullscreen />
@@ -110,12 +114,17 @@ function Buttons(): ReactNode {
 }
 
 const buttonStyle = `
-.button {
+.buttons {
   font-size: large;
   margin: 0;
   ${flex_column_center_center}
+  &.locked {
+    & > .button-item {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+  }
 }
-
 .button-item {
   margin: 1.25px;
   padding: 0.25em;
@@ -123,6 +132,7 @@ const buttonStyle = `
   ${pointer_events_initial}
   cursor: default;
   ${background_white_opaque}
+  transition: opacity 100ms;
   & > svg {
     display: block;
     width: 1.25em;

--- a/packages/lib/src/lib/ui/Right.tsx
+++ b/packages/lib/src/lib/ui/Right.tsx
@@ -55,14 +55,14 @@ const style = `
   align-items: end;
 }
 .right {
-  opacity: var(--right-scale);
   transform-origin: 100% 50%;
   &.bottom {
     transform-origin: 100% 100%;
   }
-  transform: scale(var(--right-scale)) translate3d(0px, 0px, 0px);
+  transform: translate3d(0px, 0px, 0px);
   &.not-animating {
-    --right-scale: var(--b);
+    opacity: var(--b);
+    transform: scale(var(--b));
     &.closed {
       --b: 0;
     }
@@ -83,15 +83,17 @@ const style = `
       --timing: ${timing_opening};
     }
     will-change: opacity, transform;
-    animation: xxx-right 300ms var(--timing);
+    animation: xxx-right 300ms var(--timing) forwards;
   }
 }
 @keyframes xxx-right {
   from {
-    --right-scale: var(--a);
+    opacity: var(--a);
+    transform: scale(var(--a));
   }
   to {
-    --right-scale: var(--b);
+    opacity: var(--b);
+    transform: scale(var(--b));
   }
 }
 `

--- a/packages/lib/src/lib/ui/Screen.tsx
+++ b/packages/lib/src/lib/ui/Screen.tsx
@@ -48,17 +48,14 @@ const style = `
   z-index: ${Z_INDEX_SHADOW};
 }
 .screen {
-  opacity: var(--screen-opacity);
   &.not-animating {
     &.closed {
-      --screen-opacity: 0;
       display: none;
       &.zooming {
         display: initial;
       }
     }
     &.opened {
-      --screen-opacity: 0.3;
       pointer-events: initial;
     }
   }

--- a/packages/lib/src/lib/ui/Screen.tsx
+++ b/packages/lib/src/lib/ui/Screen.tsx
@@ -13,7 +13,6 @@ import {
 } from '../css'
 import { useShadowRoot } from '../dom'
 import { notifyUi } from '../event-ui'
-import { useZoomStyleRef } from '../viewer/layout/style'
 import { useTouchMoveZoomingLock } from '../viewer/touch/event'
 import { useOnWheel } from '../wheel'
 import { useDetailStyleRef } from './style'
@@ -26,7 +25,6 @@ export function Screen(): ReactNode {
 function ScreenRoot(): ReactNode {
   const ref = useRef<HTMLDivElement>(null)
   useDetailStyleRef(ref, 'screen')
-  useZoomStyleRef(ref, 'screen')
   useTouchMoveZoomingLock(ref)
   useOnWheel(ref)
   return (
@@ -82,10 +80,10 @@ const style = `
 }
 @keyframes xxx-screen {
   from {
-    --screen-opacity: var(--a);
+    opacity: var(--a);
   }
   to {
-    --screen-opacity: var(--b);
+    opacity: var(--b);
   }
 }
 `

--- a/packages/lib/src/lib/ui/balloon-common.ts
+++ b/packages/lib/src/lib/ui/balloon-common.ts
@@ -199,17 +199,17 @@ export function calcBalloonPaths(
   }
 }
 
-export const balloonStyleString: string = `
-.balloon,
-.detail {
+export const detailStyleString: string = `
+.detail,
+.balloon {
   opacity: var(--balloon-opacity);
   transform-origin: 0 0;
 }
-.balloon {
-  transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
-}
 .detail {
   transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
+}
+.balloon {
+  transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
 }
 .not-animating {
   --balloon-opacity: var(--b);
@@ -218,15 +218,15 @@ export const balloonStyleString: string = `
   --balloon-scale: var(--b);
 }
 .animating {
-  &.balloon,
-  &.detail {
+  &.detail,
+  &.balloon {
     --duration: ${ZOOM_DURATION_DETAIL}ms;
     will-change: opacity, transform;
   }
-  &.balloon {
+  &.detail {
     animation: xxx-balloon var(--duration) var(--timing);
   }
-  &.detail {
+  &.balloon {
     animation: xxx-balloon var(--duration) var(--timing);
   }
   &.closed {

--- a/packages/lib/src/lib/ui/balloon-common.ts
+++ b/packages/lib/src/lib/ui/balloon-common.ts
@@ -220,11 +220,9 @@ export const detailStyleString: string = `
     opacity: var(--opacity);
   }
   &.detail {
-    transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
     animation: xxx-detail var(--duration) var(--timing);
   }
   &.balloon {
-    transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
     animation: xxx-balloon var(--duration) var(--timing);
   }
   &.closed {
@@ -238,42 +236,22 @@ export const detailStyleString: string = `
 @keyframes xxx-detail {
   from {
     --opacity: var(--a);
-    --balloon-translate-x: var(--tx-a-x);
-    --balloon-translate-y: var(--tx-a-y);
-    --balloon-scale: var(--a);
-    /*
     transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
-    */
   }
   to {
     --opacity: var(--b);
-    --balloon-translate-x: var(--tx-b-x);
-    --balloon-translate-y: var(--tx-b-y);
-    --balloon-scale: var(--b);
-    /*
     transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
-    */
   }
 }
 
 @keyframes xxx-balloon {
   from {
     --opacity: var(--a);
-    --balloon-translate-x: var(--tx-a-x);
-    --balloon-translate-y: var(--tx-a-y);
-    --balloon-scale: var(--a);
-    /*
     transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
-    */
   }
   to {
     --opacity: var(--b);
-    --balloon-translate-x: var(--tx-b-x);
-    --balloon-translate-y: var(--tx-b-y);
-    --balloon-scale: var(--b);
-    /*
     transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
-    */
   }
 }
 `

--- a/packages/lib/src/lib/ui/balloon-common.ts
+++ b/packages/lib/src/lib/ui/balloon-common.ts
@@ -204,10 +204,10 @@ export const detailStyleString: string = `
   transform-origin: 0 0;
   opacity: var(--b);
   &.detail {
-    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
+    transform: translate(var(--balloon-tx-b-x), var(--balloon-tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
   }
   &.balloon {
-    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
+    transform: translate(var(--balloon-tx-b-x), var(--balloon-tx-b-y)) scale(var(--b)) translate(var(--balloon-pww), var(--balloon-phh)) translate3d(0px, 0px, 0px);
   }
 }
 
@@ -235,22 +235,22 @@ export const detailStyleString: string = `
 @keyframes xxx-detail {
   from {
     opacity: var(--a);
-    transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
+    transform: translate(var(--balloon-tx-a-x), var(--balloon-tx-a-y)) scale(var(--a)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
   }
   to {
     opacity: var(--b);
-    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
+    transform: translate(var(--balloon-tx-b-x), var(--balloon-tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
   }
 }
 
 @keyframes xxx-balloon {
   from {
     opacity: var(--a);
-    transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
+    transform: translate(var(--balloon-tx-a-x), var(--balloon-tx-a-y)) scale(var(--a)) translate(var(--balloon-pww), var(--balloon-phh)) translate3d(0px, 0px, 0px);
   }
   to {
     opacity: var(--b);
-    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
+    transform: translate(var(--balloon-tx-b-x), var(--balloon-tx-b-y)) scale(var(--b)) translate(var(--balloon-pww), var(--balloon-phh)) translate3d(0px, 0px, 0px);
   }
 }
 `
@@ -349,13 +349,13 @@ export function updateBalloonStyle(
 ): void {
   const p = e.style.setProperty.bind(e.style)
   p('visibility', visibility)
-  p('--pww', pww)
-  p('--phh', phh)
+  p('--balloon-pww', pww)
+  p('--balloon-phh', phh)
   p('--a', a === null ? null : a.toString())
   p('--b', b === null ? null : b.toString())
   p('--timing', timing)
-  p('--tx-a-x', txax)
-  p('--tx-a-y', txay)
-  p('--tx-b-x', txbx)
-  p('--tx-b-y', txby)
+  p('--balloon-tx-a-x', txax)
+  p('--balloon-tx-a-y', txay)
+  p('--balloon-tx-b-x', txbx)
+  p('--balloon-tx-b-y', txby)
 }

--- a/packages/lib/src/lib/ui/balloon-common.ts
+++ b/packages/lib/src/lib/ui/balloon-common.ts
@@ -201,12 +201,12 @@ export function calcBalloonPaths(
 
 export const detailStyleString: string = `
 .not-animating {
+  transform-origin: 0 0;
+  opacity: var(--b);
   &.detail {
-    transform-origin: 0 0;
     transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
   }
   &.balloon {
-    transform-origin: 0 0;
     transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
   }
 }
@@ -217,7 +217,6 @@ export const detailStyleString: string = `
     --duration: ${ZOOM_DURATION_DETAIL}ms;
     transform-origin: 0 0;
     will-change: opacity, transform;
-    opacity: var(--opacity);
   }
   &.detail {
     animation: xxx-detail var(--duration) var(--timing);
@@ -235,22 +234,22 @@ export const detailStyleString: string = `
 
 @keyframes xxx-detail {
   from {
-    --opacity: var(--a);
+    opacity: var(--a);
     transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
   }
   to {
-    --opacity: var(--b);
+    opacity: var(--b);
     transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
   }
 }
 
 @keyframes xxx-balloon {
   from {
-    --opacity: var(--a);
+    opacity: var(--a);
     transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
   }
   to {
-    --opacity: var(--b);
+    opacity: var(--b);
     transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
   }
 }

--- a/packages/lib/src/lib/ui/balloon-common.ts
+++ b/packages/lib/src/lib/ui/balloon-common.ts
@@ -217,11 +217,11 @@ export const detailStyleString: string = `
     --duration: ${ZOOM_DURATION_DETAIL}ms;
     transform-origin: 0 0;
     will-change: opacity, transform;
-    opacity: var(--balloon-opacity);
+    opacity: var(--opacity);
   }
   &.detail {
     transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
-    animation: xxx-balloon var(--duration) var(--timing);
+    animation: xxx-detail var(--duration) var(--timing);
   }
   &.balloon {
     transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
@@ -235,18 +235,45 @@ export const detailStyleString: string = `
   }
 }
 
-@keyframes xxx-balloon {
+@keyframes xxx-detail {
   from {
-    --balloon-opacity: var(--a);
+    --opacity: var(--a);
     --balloon-translate-x: var(--tx-a-x);
     --balloon-translate-y: var(--tx-a-y);
     --balloon-scale: var(--a);
+    /*
+    transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
+    */
   }
   to {
-    --balloon-opacity: var(--b);
+    --opacity: var(--b);
     --balloon-translate-x: var(--tx-b-x);
     --balloon-translate-y: var(--tx-b-y);
     --balloon-scale: var(--b);
+    /*
+    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
+    */
+  }
+}
+
+@keyframes xxx-balloon {
+  from {
+    --opacity: var(--a);
+    --balloon-translate-x: var(--tx-a-x);
+    --balloon-translate-y: var(--tx-a-y);
+    --balloon-scale: var(--a);
+    /*
+    transform: translate(var(--tx-a-x), var(--tx-a-y)) scale(var(--a)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
+    */
+  }
+  to {
+    --opacity: var(--b);
+    --balloon-translate-x: var(--tx-b-x);
+    --balloon-translate-y: var(--tx-b-y);
+    --balloon-scale: var(--b);
+    /*
+    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
+    */
   }
 }
 `

--- a/packages/lib/src/lib/ui/balloon-common.ts
+++ b/packages/lib/src/lib/ui/balloon-common.ts
@@ -200,33 +200,31 @@ export function calcBalloonPaths(
 }
 
 export const detailStyleString: string = `
-.detail,
-.balloon {
-  opacity: var(--balloon-opacity);
-  transform-origin: 0 0;
-}
-.detail {
-  transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
-}
-.balloon {
-  transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
-}
 .not-animating {
-  --balloon-opacity: var(--b);
-  --balloon-translate-x: var(--tx-b-x);
-  --balloon-translate-y: var(--tx-b-y);
-  --balloon-scale: var(--b);
+  &.detail {
+    transform-origin: 0 0;
+    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
+  }
+  &.balloon {
+    transform-origin: 0 0;
+    transform: translate(var(--tx-b-x), var(--tx-b-y)) scale(var(--b)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
+  }
 }
+
 .animating {
   &.detail,
   &.balloon {
     --duration: ${ZOOM_DURATION_DETAIL}ms;
+    transform-origin: 0 0;
     will-change: opacity, transform;
+    opacity: var(--balloon-opacity);
   }
   &.detail {
+    transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(-50%, -50%) translate3d(0px, 0px, 0px);
     animation: xxx-balloon var(--duration) var(--timing);
   }
   &.balloon {
+    transform: translate(var(--balloon-translate-x), var(--balloon-translate-y)) scale(var(--balloon-scale)) translate(var(--pww), var(--phh)) translate3d(0px, 0px, 0px);
     animation: xxx-balloon var(--duration) var(--timing);
   }
   &.closed {
@@ -236,6 +234,7 @@ export const detailStyleString: string = `
     --timing: ${timing_opening};
   }
 }
+
 @keyframes xxx-balloon {
   from {
     --balloon-opacity: var(--a);

--- a/packages/lib/src/lib/ui/ui-xstate.ts
+++ b/packages/lib/src/lib/ui/ui-xstate.ts
@@ -100,10 +100,13 @@ const uiMachine = setup({
     updateBalloonStyle: ({ context }) =>
       context.balloon &&
       updateBalloonStyleRefs(context.balloon, context.m['detail']),
-    updateDetailStyle: ({ context }) =>
-      updateDetailStyleRefs(context.m['detail']),
-    updateDetailScrollStyle: ({ context }) =>
-      updateDetailScrollStyleRefs(context.m['detail']),
+    updateDetailStyle: ({ context }) => {
+      const oc = context.m['detail']
+      requestAnimationFrame(() => {
+        updateDetailStyleRefs(oc)
+        requestAnimationFrame(() => updateDetailScrollStyleRefs(oc))
+      })
+    },
   },
 }).createMachine({
   type: 'parallel',
@@ -181,7 +184,6 @@ const uiMachine = setup({
                 'updateHeaderStyle',
                 'updateBalloonStyle',
                 'updateDetailStyle',
-                'updateDetailScrollStyle',
               ],
               on: {
                 DONE: [
@@ -212,7 +214,6 @@ const uiMachine = setup({
                 'updateHeaderStyle',
                 'updateBalloonStyle',
                 'updateDetailStyle',
-                'updateDetailScrollStyle',
               ],
               exit: 'endCancel',
               on: {
@@ -252,7 +253,6 @@ const uiMachine = setup({
             { type: 'handle', params: { part: 'detail' } },
             'updateBalloonStyle',
             'updateDetailStyle',
-            'updateDetailScrollStyle',
             assign({
               animationEnded: ({ context }) => ({
                 ...context.animationEnded,

--- a/packages/lib/src/lib/viewer/Container.tsx
+++ b/packages/lib/src/lib/viewer/Container.tsx
@@ -13,7 +13,6 @@ import { useAppearingStyleRef } from '../style/appearing'
 import { useDetailStyleRef } from '../ui/style'
 import { sendContextMenu } from './input/input'
 import { useZoomStyleRef } from './layout/style'
-import { useLayoutStyleRef } from './layout/style'
 import { useScrollRef } from './scroll/style'
 import { useTouchMoveZoomingLock } from './touch/event'
 import {
@@ -28,7 +27,6 @@ export function Container(props: Readonly<PropsWithChildren>): ReactNode {
   useDetailStyleRef(ref, 'container')
   useTouchMoveZoomingLock(ref)
   useZoomStyleRef(ref, 'container')
-  useLayoutStyleRef(ref, 'container')
   useAppearingStyleRef(ref, 'container')
   useScrollRef(ref, 'container')
   return (

--- a/packages/lib/src/lib/viewer/Container.tsx
+++ b/packages/lib/src/lib/viewer/Container.tsx
@@ -80,7 +80,7 @@ const style: string = `
     ${position_absolute_left_0_top_0}
     contain: strict;
     transform: var(--layout-content-matrix) translate3d(0, 0, 0);
-    transform-origin: left top;
+    transform-origin: 0% 0%;
     pointer-events: none;
     width: var(--layout-scroll-width);
     height: var(--layout-scroll-height);

--- a/packages/lib/src/lib/viewer/Container.tsx
+++ b/packages/lib/src/lib/viewer/Container.tsx
@@ -97,7 +97,6 @@ const style: string = `
     animation: xxx-appearing 2s ${timing_opening};
   }
 }
-
 @keyframes xxx-appearing {
   from {
     opacity: 0;

--- a/packages/lib/src/lib/viewer/layout/style.ts
+++ b/packages/lib/src/lib/viewer/layout/style.ts
@@ -15,10 +15,10 @@ import { viewerSend } from '../viewer-xstate'
 import { fromSvgToContent } from './coord'
 import type { Layout } from './layout-types'
 
-const layoutStyleRefs: Map<string, HTMLDivElement> = new Map()
+const layoutStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
 
 export function useLayoutStyleRef(
-  ref: Readonly<RefObject<HTMLDivElement | null>>,
+  ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
   name: string
 ): void {
   useStyleRef(layoutStyleRefs, ref, name)
@@ -45,10 +45,10 @@ export function updateLayoutStyleRefs(layout: Readonly<Layout>): void {
 
 ////
 
-const zoomStyleRefs: Map<string, HTMLDivElement> = new Map()
+const zoomStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
 
 export function useZoomStyleRef(
-  ref: Readonly<RefObject<HTMLDivElement | null>>,
+  ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
   name: string
 ): void {
   useStyleRef(zoomStyleRefs, ref, name)
@@ -60,13 +60,17 @@ export function updateZoomStyleRefs(
 ): void {
   const o =
     animation === null || animation.origin === null
-      ? `left top`
+      ? `0% 0%`
       : `${animation.origin.x}px ${animation?.origin.y}px`
   Array.from(zoomStyleRefs, ([, e]) => {
     const p = e.style.setProperty.bind(e.style)
     tag(e, 'zooming', animation !== null)
     p(`--zoom-origin`, o)
     p(`--zoom-zoom`, zoom.toString())
+    p(`--zoom-s`, null)
+    p(`--zoom-s-inv`, null)
+    p(`--zoom-k`, null)
+    p(`--zoom-k-inv`, null)
   })
   if (animation !== null)
     startLoop('zoom', 500, {
@@ -91,7 +95,11 @@ type ZoomValues = Readonly<{
   readonly sinv: number
   readonly z: number
   readonly zinv: number
+  readonly k: number
+  readonly kinv: number
 }>
+
+const getK = (zoom: number): number => 0.5 + 0.5 * Math.log2(Math.max(1, zoom))
 
 function getCurrentZoomValues(
   { animation, zoom }: ZoomData,
@@ -105,12 +113,15 @@ function getCurrentZoomValues(
   const za = zoom
   const zb = zoom * s
   const z = lerp(za, zb, easeCubic(t))
-  return { tx, ty, s, sinv: 1 / s, z, zinv: 1 / z }
+  const ka = getK(zoom)
+  const kb = getK(zoom * s)
+  const k = lerp(ka, kb, easeCubic(t))
+  return { tx, ty, s, sinv: 1 / s, z, zinv: 1 / z, k, kinv: 1 / k }
 }
 
 function tickZoomStyleRefs(t: number, cbdata?: ZoomData): void {
   if (!cbdata) return
-  const { tx, ty, s, sinv, z, zinv } = getCurrentZoomValues(cbdata, t)
+  const { tx, ty, s, sinv, z, zinv, k, kinv } = getCurrentZoomValues(cbdata, t)
   Array.from(zoomStyleRefs, ([, e]) => {
     const p = e.style.setProperty.bind(e.style)
     p(`--zoom-tx`, `${tx}px`)
@@ -119,5 +130,7 @@ function tickZoomStyleRefs(t: number, cbdata?: ZoomData): void {
     p(`--zoom-s-inv`, `${sinv}`)
     p(`--zoom-z`, `${z}`)
     p(`--zoom-z-inv`, `${zinv}`)
+    p(`--zoom-k`, `${k}`)
+    p(`--zoom-k-inv`, `${kinv}`)
   })
 }

--- a/packages/lib/src/lib/viewer/layout/style.ts
+++ b/packages/lib/src/lib/viewer/layout/style.ts
@@ -80,11 +80,12 @@ export function updateZoomStyleRefs(
     p(`--zoom-k-inv`, null)
   })
   Array.from(zoomSStyleRefs, ([, e]) => {
-    tag(e, 'zooming', animation !== null)
     const p = e.style.setProperty.bind(e.style)
     p(`--zoom-s`, animation === null ? null : animation.to.a.toString())
+    p(`--zoom-s-symbols`, animation === null ? null : animation.to.a.toString())
+    tag(e, 'zooming', animation !== null)
   })
-  if (animation !== null)
+  if (animation !== null) {
     startLoop('zoom', 500, {
       tickcb: tickZoomStyleRefs,
       donecb: () => {
@@ -93,6 +94,13 @@ export function updateZoomStyleRefs(
       },
       cbdata: { animation, zoom },
     })
+    /*
+    startLoop('zoomS', 500, {
+      tickcb: tickZoomSStyleRefs,
+      cbdata: { animation, zoom },
+    })
+    */
+  }
 }
 
 type ZoomData = Readonly<{
@@ -146,3 +154,15 @@ function tickZoomStyleRefs(t: number, cbdata?: ZoomData): void {
     p(`--zoom-k-inv`, `${kinv}`)
   })
 }
+
+/*
+function tickZoomSStyleRefs(t: number, cbdata?: ZoomData): void {
+  if (!cbdata) return
+  const { s } = getCurrentZoomValues(cbdata, t)
+  Array.from(zoomStyleRefs, ([, e]) => {
+    const p = e.style.setProperty.bind(e.style)
+    p(`--zoom-s`, `${s}`)
+    //p(`--zoom-s-symbols`, `${s}`)
+  })
+}
+*/

--- a/packages/lib/src/lib/viewer/layout/style.ts
+++ b/packages/lib/src/lib/viewer/layout/style.ts
@@ -46,12 +46,19 @@ export function updateLayoutStyleRefs(layout: Readonly<Layout>): void {
 ////
 
 const zoomStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
+const zoomSStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
 
 export function useZoomStyleRef(
   ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
   name: string
 ): void {
   useStyleRef(zoomStyleRefs, ref, name)
+}
+export function useZoomSStyleRef(
+  ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
+  name: string
+): void {
+  useStyleRef(zoomSStyleRefs, ref, name)
 }
 
 export function updateZoomStyleRefs(
@@ -71,6 +78,11 @@ export function updateZoomStyleRefs(
     p(`--zoom-s-inv`, null)
     p(`--zoom-k`, null)
     p(`--zoom-k-inv`, null)
+  })
+  Array.from(zoomSStyleRefs, ([, e]) => {
+    tag(e, 'zooming', animation !== null)
+    const p = e.style.setProperty.bind(e.style)
+    p(`--zoom-s`, animation === null ? null : animation.to.a.toString())
   })
   if (animation !== null)
     startLoop('zoom', 500, {

--- a/packages/lib/src/lib/viewer/layout/style.ts
+++ b/packages/lib/src/lib/viewer/layout/style.ts
@@ -32,6 +32,8 @@ export function updateLayoutStyleRefs(layout: Readonly<Layout>): void {
   const svgToContent = fromSvgToContent(layout)
   Array.from(layoutStyleRefs, ([, e]) => {
     const p = e.style.setProperty.bind(e.style)
+    p(`--layout-container-width`, `${trunc2(layout.container.width)}px`)
+    p(`--layout-container-height`, `${trunc2(layout.container.height)}px`)
     p(`--layout-content-matrix`, layout.content.toString())
     p(`--layout-scroll-width`, `${trunc2(layout.scroll.width)}px`)
     p(`--layout-scroll-height`, `${trunc2(layout.scroll.height)}px`)

--- a/packages/lib/src/lib/viewer/layout/style.ts
+++ b/packages/lib/src/lib/viewer/layout/style.ts
@@ -16,12 +16,19 @@ import { fromSvgToContent } from './coord'
 import type { Layout } from './layout-types'
 
 const layoutStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
+const svgScaleStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
 
 export function useLayoutStyleRef(
   ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
   name: string
 ): void {
   useStyleRef(layoutStyleRefs, ref, name)
+}
+export function useSvgScaleStyleRef(
+  ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
+  name: string
+): void {
+  useStyleRef(svgScaleStyleRefs, ref, name)
 }
 
 function matrixTrunc2(m: DOMMatrixReadOnly): DOMMatrixReadOnly {
@@ -38,6 +45,12 @@ export function updateLayoutStyleRefs(layout: Readonly<Layout>): void {
     p(`--layout-scroll-width`, `${trunc2(layout.scroll.width)}px`)
     p(`--layout-scroll-height`, `${trunc2(layout.scroll.height)}px`)
     p(`--layout-svg-to-content-matrix`, matrixTrunc2(svgToContent).toString())
+  })
+}
+
+export function updateSvgScaleStyleRefs(layout: Readonly<Layout>): void {
+  Array.from(svgScaleStyleRefs, ([, e]) => {
+    const p = e.style.setProperty.bind(e.style)
     p(`--layout-svgscale`, `${trunc2(layout.svgScale)}`)
     p(`--layout-fontsize`, `${trunc2(layout.config.fontSize)}`)
   })

--- a/packages/lib/src/lib/viewer/layout/style.ts
+++ b/packages/lib/src/lib/viewer/layout/style.ts
@@ -38,6 +38,8 @@ export function updateLayoutStyleRefs(layout: Readonly<Layout>): void {
     p(`--layout-scroll-width`, `${trunc2(layout.scroll.width)}px`)
     p(`--layout-scroll-height`, `${trunc2(layout.scroll.height)}px`)
     p(`--layout-svg-to-content-matrix`, matrixTrunc2(svgToContent).toString())
+    p(`--layout-svgscale`, `${trunc2(layout.svgScale)}`)
+    p(`--layout-fontsize`, `${trunc2(layout.config.fontSize)}`)
   })
 }
 

--- a/packages/lib/src/lib/viewer/layout/style.ts
+++ b/packages/lib/src/lib/viewer/layout/style.ts
@@ -60,6 +60,7 @@ export function updateSvgScaleStyleRefs(layout: Readonly<Layout>): void {
 
 const zoomStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
 const zoomSStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
+const zoomCondStyleRefs: Map<string, HTMLElement | SVGElement> = new Map()
 
 export function useZoomStyleRef(
   ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
@@ -72,6 +73,12 @@ export function useZoomSStyleRef(
   name: string
 ): void {
   useStyleRef(zoomSStyleRefs, ref, name)
+}
+export function useZoomCondStyleRef(
+  ref: Readonly<RefObject<HTMLElement | SVGElement | null>>,
+  name: string
+): void {
+  useStyleRef(zoomCondStyleRefs, ref, name)
 }
 
 export function updateZoomStyleRefs(
@@ -96,6 +103,9 @@ export function updateZoomStyleRefs(
     const p = e.style.setProperty.bind(e.style)
     p(`--zoom-s`, animation === null ? null : animation.to.a.toString())
     p(`--zoom-s-symbols`, animation === null ? null : animation.to.a.toString())
+    tag(e, 'zooming', animation !== null)
+  })
+  Array.from(zoomCondStyleRefs, ([, e]) => {
     tag(e, 'zooming', animation !== null)
   })
   if (animation !== null) {

--- a/packages/lib/src/lib/viewer/scroll/scroll.ts
+++ b/packages/lib/src/lib/viewer/scroll/scroll.ts
@@ -9,8 +9,8 @@ import { type CurrentScroll } from '../../../types'
 import { boxUnit, type BoxBox } from '../../box/prefixed'
 import { tag } from '../../style/tag'
 
-export const busies: Map<string, number> = new Map()
-export const locks: Set<string> = new Set()
+const busies: Map<string, number> = new Map()
+const locks: Set<string> = new Set()
 
 export const scrollLockRefs: Map<string, HTMLElement | SVGElement> = new Map()
 
@@ -50,19 +50,6 @@ export function stopScroll(e: Readonly<HTMLElement>): void {
 }
 */
 
-export const busies: Map<string, number> = new Map()
-export const locks: Set<string> = new Set()
-export function lockScroll(): boolean {
-  if (busies.has('S')) return false
-  //stopScroll()
-  locks.add('S')
-  return true
-}
-export function unlockScroll(): boolean {
-  if (!locks.has('S')) return false
-  locks.delete('S')
-  return true
-}
 /*
 export function stopScroll(e: Readonly<HTMLElement>): void {
   const x = e.scrollLeft

--- a/packages/lib/src/lib/viewer/scroll/scroll.ts
+++ b/packages/lib/src/lib/viewer/scroll/scroll.ts
@@ -8,6 +8,30 @@ import { createAtom, type Atom } from '@xstate/store'
 import { type CurrentScroll } from '../../../types'
 import { boxUnit, type BoxBox } from '../../box/prefixed'
 
+export const busies: Map<string, number> = new Map()
+export const locks: Set<string> = new Set()
+export function lockScroll(): boolean {
+  if (busies.has('S')) return false
+  //stopScroll()
+  locks.add('S')
+  return true
+}
+export function unlockScroll(): boolean {
+  if (!locks.has('S')) return false
+  locks.delete('S')
+  return true
+}
+/*
+export function stopScroll(e: Readonly<HTMLElement>): void {
+  const x = e.scrollLeft
+  const y = e.scrollTop
+  e.style.position = 'fixed'
+  e.style.left = `-${x}px`
+  e.style.top = `-${y}px`
+  e.style.width = '100%'
+}
+*/
+
 // XXX make this async
 // XXX call this from scroll-xstate as invoke (Promise)
 // XXX return status

--- a/packages/lib/src/lib/viewer/scroll/scroll.ts
+++ b/packages/lib/src/lib/viewer/scroll/scroll.ts
@@ -7,15 +7,33 @@ import { createAtom, type Atom } from '@xstate/store'
 
 import { type CurrentScroll } from '../../../types'
 import { boxUnit, type BoxBox } from '../../box/prefixed'
+import { tag } from '../../style/tag'
 
 export const busies: Map<string, number> = new Map()
 export const locks: Set<string> = new Set()
+
+export const scrollLockRefs: Map<string, HTMLElement | SVGElement> = new Map()
+
+export function busyScroll(): void {
+  const prevId = busies.get('S')
+  if (prevId) clearTimeout(prevId)
+  const id = setTimeout(() => {
+    busies.delete('S')
+    Array.from(scrollLockRefs, ([, e]) => tag(e, 'locked', false))
+  }, 500)
+  busies.set('S', id)
+  Array.from(scrollLockRefs, ([, e]) => tag(e, 'locked', true))
+}
+
+export function unbusyScroll(): void {}
+
 export function lockScroll(): boolean {
   if (busies.has('S')) return false
   //stopScroll()
   locks.add('S')
   return true
 }
+
 export function unlockScroll(): boolean {
   if (!locks.has('S')) return false
   locks.delete('S')

--- a/packages/lib/src/lib/viewer/viewer-react.ts
+++ b/packages/lib/src/lib/viewer/viewer-react.ts
@@ -1,5 +1,5 @@
 import { notifyScroll } from '../event-scroll'
-import { busies } from './scroll/scroll'
+import { busyScroll } from './scroll/scroll'
 import { clickeventmask, viewerSend, viewerSendEvent } from './viewer-xstate'
 
 export function sendClick(ev: React.MouseEvent<HTMLDivElement>): void {
@@ -10,10 +10,7 @@ export function sendClick(ev: React.MouseEvent<HTMLDivElement>): void {
 }
 export function sendScroll(ev: React.UIEvent<HTMLDivElement, Event>): void {
   if (ev === null) return
-  const prevId = busies.get('S')
-  if (prevId) clearTimeout(prevId)
-  const id = setTimeout(() => busies.delete('S'), 500)
-  busies.set('S', id)
+  busyScroll()
   notifyScroll.eventTick(ev)
 }
 export function sendAnimationEnd(

--- a/packages/lib/src/lib/viewer/viewer-react.ts
+++ b/packages/lib/src/lib/viewer/viewer-react.ts
@@ -1,4 +1,5 @@
 import { notifyScroll } from '../event-scroll'
+import { busies } from './scroll/scroll'
 import { clickeventmask, viewerSend, viewerSendEvent } from './viewer-xstate'
 
 export function sendClick(ev: React.MouseEvent<HTMLDivElement>): void {
@@ -8,9 +9,12 @@ export function sendClick(ev: React.MouseEvent<HTMLDivElement>): void {
   viewerSend({ type: 'SEARCH', pos: { x: ev.pageX, y: ev.pageY } })
 }
 export function sendScroll(ev: React.UIEvent<HTMLDivElement, Event>): void {
-  if (ev !== null) {
-    notifyScroll.eventTick(ev)
-  }
+  if (ev === null) return
+  const prevId = busies.get('S')
+  if (prevId) clearTimeout(prevId)
+  const id = setTimeout(() => busies.delete('S'), 500)
+  busies.set('S', id)
+  notifyScroll.eventTick(ev)
 }
 export function sendAnimationEnd(
   ev: React.AnimationEvent<HTMLDivElement>

--- a/packages/lib/src/lib/viewer/viewer-xstate.ts
+++ b/packages/lib/src/lib/viewer/viewer-xstate.ts
@@ -196,11 +196,13 @@ const viewerMachine = setup({
           target: 'Resizing',
         },
         SEARCH: {
+          guard: () => lockScroll(),
           actions: { type: 'prepareSearch', params: ({ event }) => event },
           target: 'Searching',
         },
         SWITCH: {
           // switch only when viewer is idle!
+          guard: () => lockScroll(),
           actions: {
             type: 'emitSwitch',
             params: ({ event }) => event,
@@ -208,6 +210,7 @@ const viewerMachine = setup({
           target: 'Switching',
         },
         RECENTER: {
+          guard: () => lockScroll(),
           target: 'Recentering',
         },
         ZOOM: {
@@ -219,10 +222,12 @@ const viewerMachine = setup({
           target: 'Zooming',
         },
         HOME: {
+          guard: () => lockScroll(),
           actions: 'prepareHome',
           target: 'Zooming',
         },
         ROTATE: {
+          guard: () => lockScroll(),
           actions: 'prepareRotate',
           target: 'Zooming',
         },

--- a/packages/lib/src/lib/viewer/viewer-xstate.ts
+++ b/packages/lib/src/lib/viewer/viewer-xstate.ts
@@ -14,6 +14,7 @@ import { touchCbs } from '../event-touch'
 import { notifyUi, uiCbs } from '../event-ui'
 import { setZooming } from './layout/animation'
 import { emptyLayout } from './layout/layout'
+import { lockScroll, unlockScroll } from './scroll/scroll'
 import {
   clearAnimation,
   emitGetScroll,
@@ -119,6 +120,7 @@ const viewerMachine = setup({
 
     enterZooming: () => setZooming(true),
     exitZooming: () => setZooming(false),
+    unlockScroll: () => unlockScroll(),
   },
 }).createMachine({
   id: 'viewer',
@@ -209,6 +211,7 @@ const viewerMachine = setup({
           target: 'Recentering',
         },
         ZOOM: {
+          guard: () => lockScroll(),
           actions: {
             type: 'prepareZoom',
             params: ({ event }) => event,
@@ -326,7 +329,7 @@ const viewerMachine = setup({
       initial: 'Stopping',
       onDone: 'Idle',
       entry: 'enterZooming',
-      exit: 'exitZooming',
+      exit: ['exitZooming', 'unlockScroll'],
       states: {
         // XXX
         // XXX stop scroll before really start zooming


### PR DESCRIPTION
- **lib: update measure coord via ref**
- **use gpu for coordinate**
- **lib: refactor measure to make styles static**
- **lib: refactor guides**
- **lib: update guides/measure/coordinate via refs**
- **lib: refactor markers rendering**
- **minor render refactor**
- **wip**
- **Revert "lib: refactor balloon css"**
- **Revert "lib: simplify balloon css"**
- **Revert "lib: refactor balloon css"**
- **Revert "lib: split balloon animation into vars"**
- **lib: revert Screen to use keyframes opacity**
- **lib: revert map symbols to not use rAF**
- **support css animation symbol relative zoom (safari broken)**
- **lock zoom while scroll is busy**
- **more scroll locks**
- **disable ui buttons while scroll is busy**
- **define**
- **make --layout-svgscale inheritable**
- **fix ui components not to use custom vars**
- **stop inheriting most css vars**
- **cache rgb color**
- **Container does not need layout vars**
- **split --layout-svgscale/--layout-fontsize**
- **improve balloon/detail animation perl**
- **update svgscale style refs**
- **checkpoint relative labels/symbols + content layout style refs**
- **define @property in App.css**
- **sort**
- **refactor css @property**
- **cache distance paths**
- **refactor distance style**
- **reduce gpu layers**
- **fix floors style ref**
- **fix previous**
- **floors html needs two transforms**
- **comment**
- **guides style fixes**
- **fix initial left style**
- **minor optimization to map html (contain / content-visibility)**
